### PR TITLE
Fixed Commodore 64 loading with wrong core VICE xvic (VIC-20)

### DIFF
--- a/assets/root/.allium/config/consoles.toml
+++ b/assets/root/.allium/config/consoles.toml
@@ -204,8 +204,40 @@ extensions = [
 [[consoles]]
 name = "Commodore 64"
 cores = ["vice_x64"]
-patterns = ["COMMODORE"]
-
+patterns = ["COMMODORE", "C64"]
+extensions = [
+    "d64",
+    "d71",
+    "d80",
+    "d81",
+    "d82",
+    "g64",
+    "g41",
+    "x64",
+    "t64",
+    "tap",
+    "prg",
+    "p00",
+    "crt",
+    "bin",
+    "zip",
+    "gz",
+    "d6z",
+    "d7z",
+    "d8z",
+    "g6z",
+    "g4z",
+    "x6z",
+    "cmd",
+    "m3u",
+    "vfl",
+    "vsf",
+    "nib",
+    "nbz",
+    "d2m",
+    "d4m",
+]
+    
 [[consoles]]
 name = "VIC-20"
 cores = ["vice_xvic"]


### PR DESCRIPTION
Commodore 64 games was not working because loading with VICE xvic core instead of  VICE x64.

I also added another pattern folder.