### PR TITLE
lang: Add German translation

### DIFF
--- a/assets/root/.allium/locales/de-DE/activity-tracker.ftl
+++ b/assets/root/.allium/locales/de-DE/activity-tracker.ftl
@@ -1,0 +1,3 @@
+activity-tracker-title = Aktivitäts-Tracker
+
+activity-tracker-play-time = { $hours_decimal } Stunden

--- a/assets/root/.allium/locales/de-DE/main.ftl
+++ b/assets/root/.allium/locales/de-DE/main.ftl
@@ -1,0 +1,115 @@
+# Launcher
+tab-recents = Verlauf
+tab-games = Spiele
+tab-apps = Apps
+tab-settings = Einstellungen
+
+sort-alphabetical = Sortierung: A-Z
+sort-last-played = Sortierung: Zuletzt
+sort-most-played = Sortierung: Spielzeit
+sort-random = Sortierung: Zufall
+sort-search = Suche
+
+populating-database = Fülle Datenbank...
+    Dies kann einige Minuten dauern.
+    Geh einen Kaffee trinken!
+populating-games = Spiele werden aktualisiert... ({ $directory })
+
+menu-launch = Starten
+menu-launch-with-core = Starten mit { $core }
+menu-reset = Reset
+menu-remove-from-recents = Aus Verlauf entfernen
+menu-repopulate-database = Datenbank neu füllen
+
+settings-wifi = WLAN
+settings-wifi-wifi-enabled = WLAN aktiviert
+settings-wifi-ip-address = IP-Adresse
+settings-wifi-wifi-network = WLAN-Netzwerk
+settings-wifi-wifi-password = WLAN-Passwort
+settings-wifi-ntp-enabled = NTP aktiviert
+settings-wifi-telnet-enabled = Telnet aktiviert
+settings-wifi-ftp-enabled = FTP aktiviert
+settings-wifi-connecting= Verbinde...
+
+settings-clock = Datum und Uhrzeit
+settings-clock-datetime = Datum und Uhrzeit
+settings-clock-timezone = Zeitzone
+
+settings-display = Bildschirm
+settings-display-luminance = Helligkeit
+settings-display-hue = Farbton
+settings-display-contrast = Kontrast
+settings-display-saturation = Sättigung
+settings-display-red = Rot
+settings-display-green = Grün
+settings-display-blue = Blau
+settings-display-screen-resolution = Bildschirmauflösung
+
+settings-theme = Design
+settings-theme-dark-mode = Dunkles Design
+settings-theme-ui-font = UI Schriftart
+settings-theme-ui-font-size = UI Schriftgröße
+settings-theme-guide-font = Schriftart Anleitung
+settings-theme-guide-font-size = Schriftgröße Anleitung
+settings-theme-highlight-color = Hervorhebungsfarbe
+settings-theme-foreground-color = Vordergrundfarbe
+settings-theme-background-color = Hintergrundfarbe
+settings-theme-disabled-color = Deaktivierte Farbe
+settings-theme-button-a-color = Farbe Knopf A
+settings-theme-button-b-color = Farbe Knopf B
+settings-theme-button-x-color = Farbe Knopf X
+settings-theme-button-y-color = Farbe Knopf Y
+
+settings-language = Sprache
+settings-language-language = Sprache
+
+settings-files = Dateien
+
+settings-about = Über
+settings-about-allium-version = Allium-Version
+settings-about-model-name = Modell
+settings-about-firmware-version = Firmware-Version
+settings-about-operating-system-version = Betriebssystem
+settings-about-kernel-version = Kernel-Version
+settings-about-memory-used = Arbeitsspeicher belegt
+settings-about-unknown-value = Unbekannt
+
+# Menu
+ingame-menu-continue = Fortsetzen
+ingame-menu-save = Speichern
+ingame-menu-load = Laden
+ingame-menu-reset = Reset
+ingame-menu-settings = Optionen
+ingame-menu-guide = Anleitung
+ingame-menu-quit = Beenden
+ingame-menu-slot = Slot { $slot }
+ingame-menu-slot-auto = Auto
+ingame-menu-disk = Slot { $disk }
+
+guide-button-search = Suchen
+guide-button-next = Weiter
+guide-button-prev = Zurück
+
+# Hotkeys
+hotkeys-global = Globale Tastenkürzel:
+hotkeys-screenshot = Bildschirmfoto
+hotkeys-volume-down = Lautstärke -
+hotkeys-volume-up = Lautstärke +
+hotkeys-brightness-down = Helligkeit -
+hotkeys-brightness-up = Helligkeit +
+
+hotkeys-ingame = Tastenkürzel im Spiel:
+hotkeys-toggle-aspect-ratio = Seitenverhältnis umschalten
+hotkeys-toggle-fps = FPS umschalten
+
+# Common
+button-back = Zurück
+button-confirm = OK
+button-edit = Bearbeiten
+button-select = Auswählen
+
+keyboard-button-backspace = Löschen
+keyboard-button-shift = Umschalttaste
+
+powering-off = Ausschalten...
+charging = Aufladen...

--- a/assets/root/.allium/locales/en-US/langs.ftl
+++ b/assets/root/.allium/locales/en-US/langs.ftl
@@ -1,3 +1,4 @@
+lang-de-DE = Deutsch
 lang-en-GB = English (United Kingdom)
 lang-en-US = English (United States)
 lang-es-CO = Español (Latino)


### PR DESCRIPTION
Add German translation.

Some words were chosen suboptimally to fit in the existing space, like "Reset" instead of "Zurücksetzen"