### PR TITLE
fix typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ $(DIST_DIR)/.allium/bin/dufs:
 $(DIST_DIR)/.allium/bin/syncthing:
 	cd "$(mktemp --directory)"
 	wget "https://github.com/syncthing/syncthing/releases/download/v2.0.10/syncthing-linux-arm-v2.0.10.tar.gz" -O syncthing.tar.gz
+	tar xf syncthing.tar.gz
 	mv "syncthing-linux-arm-v2.0.10/syncthing" "$(DIST_DIR)/.allium/bin/syncthing"
 
 DRASTIC_URL := https://github.com/steward-fu/nds/releases/download/v1.8/drastic-v1.8_miyoo.zip


### PR DESCRIPTION
Fix a typo which causes the syncthing download to extract in the wrong place.