### PR TITLE
cargo: optimise ARM build for Cortex-A7

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+[target.arm-unknown-linux-gnueabihf]
+rustflags = ["-C", "target-cpu=cortex-a7"]


### PR DESCRIPTION
Should eke out a little more performance out of the allium binaries on our beloved Miyoos