### PR TITLE
Terminal: Garbled screen on exit fix

### DIFF
--- a/static/Apps/Terminal (st).pak/launch.sh
+++ b/static/Apps/Terminal (st).pak/launch.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
 HOME=/mnt/SDCARD ./st
+cat /dev/zero > /dev/fb0 2>/dev/null


### PR DESCRIPTION
Adds a line to Terminal's launch script that blacks out the screen immediately after exiting the app. This hides the garbled screen that shows up on 750x560 resolution devices (MMv4 & MMF) when the resolution changes after exiting apps that run in 640x480 mode. This has no negative consequences for 640x480 devices, and thus needs no device-specific logic.

I first developed this solution for an improved PICO-8 launch script and a Super Haxagon launch script which I will make PRs for once I have tested them further.