### PR TITLE
fix: Restore volume after exiting Drastic

### DIFF
--- a/static/.allium/cores/drastic/launch.sh
+++ b/static/.allium/cores/drastic/launch.sh
@@ -30,3 +30,4 @@ set_snd_level &
 if [ -f /mnt/SDCARD/.tmp_update/script/start_audioserver.sh ]; then
     /mnt/SDCARD/.tmp_update/script/start_audioserver.sh
 fi
+set_snd_level

--- a/static/.allium/cores/drastic/launch.sh
+++ b/static/.allium/cores/drastic/launch.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set_snd_level() {
-    sleep 3
+    sleep 0.5
     local start_time
     local elapsed_time
 


### PR DESCRIPTION
Sets sound level again after exiting Drastic as current volume is clobbered both when stopping and starting the audioserver.

Bonus: Reduced the sleep time for set_snd_level, which prevents you from hearing a loud burst of sound when starting Drastic due to it taking too long to restore the sound level.


Aside: I have realized I am using exact copies of  set_snd_level for my PICO-8 and SuperHaxagon scripts, my next PR will likely be moving set_snd_level into its own script.