### PR TITLE
chore: migrate set_snd_level function to its own script

### DIFF
--- a/static/.allium/cores/drastic/launch.sh
+++ b/static/.allium/cores/drastic/launch.sh
@@ -1,33 +1,9 @@
 #!/bin/sh
 
-set_snd_level() {
-    sleep 0.5
-    local start_time
-    local elapsed_time
-
-    start_time=$(date +%s)
-    while [ ! -e /proc/mi_modules/mi_ao/mi_ao0 ]; do
-        sleep 0.2
-        elapsed_time=$(($(date +%s) - start_time))
-        if [ "$elapsed_time" -ge 30 ]; then
-            return 1
-        fi
-    done
-
-    vol=$(cat /tmp/volume 2>/dev/null)
-    [ -n "$vol" ] || vol=-9
-
-    echo "set_ao_mute 0" >/proc/mi_modules/mi_ao/mi_ao0
-    echo "set_ao_volume 0 ${vol}dB" >/proc/mi_modules/mi_ao/mi_ao0
-    echo "set_ao_volume 1 ${vol}dB" >/proc/mi_modules/mi_ao/mi_ao0
-
-}
-
-set_snd_level &
-
+/mnt/SDCARD/.tmp_update/script/set_sound_level.sh &
 "$ROOT"/.allium/cores/drastic/drastic/launch.sh "$@"
 
 if [ -f /mnt/SDCARD/.tmp_update/script/start_audioserver.sh ]; then
     /mnt/SDCARD/.tmp_update/script/start_audioserver.sh
 fi
-set_snd_level
+/mnt/SDCARD/.tmp_update/script/set_sound_level.sh

--- a/static/.tmp_update/script/set_sound_level.sh
+++ b/static/.tmp_update/script/set_sound_level.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+sleep 0.5
+local start_time
+local elapsed_time
+
+start_time=$(date +%s)
+while [ ! -e /proc/mi_modules/mi_ao/mi_ao0 ]; do
+    sleep 0.2
+    elapsed_time=$(($(date +%s) - start_time))
+    if [ "$elapsed_time" -ge 30 ]; then
+        return 1
+    fi
+done
+
+vol=$(cat /tmp/volume 2>/dev/null)
+[ -n "$vol" ] || vol=-9
+
+echo "set_ao_mute 0" >/proc/mi_modules/mi_ao/mi_ao0
+echo "set_ao_volume 0 ${vol}dB" >/proc/mi_modules/mi_ao/mi_ao0
+echo "set_ao_volume 1 ${vol}dB" >/proc/mi_modules/mi_ao/mi_ao0


### PR DESCRIPTION
Migrates this function from Drastic's launch script to its own set_sound_level.sh script that sits alongside start_audioserver.sh and stop_audioserver.sh. This will allow it be re-used for other launch scripts that need it, like the improved PICO-8 launch script, my next PR.