### PR TITLE
Fixed make all on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ $(RETROARCH)/bin/retroarch_miyoo354:
 	docker run --rm -v /$(ROOT_DIR)/$(RETROARCH):/root/workspace $(TOOLCHAIN) bash -c "source /root/.bashrc; make all"
 
 $(DIST_DIR)/.allium/bin/dufs:
-	cd third-party/dufs && cargo zigbuild --release --target=$(TARGET_TRIPLE).$(GLIBC_VERSION)
+	cd third-party/dufs && LZMA_API_STATIC=1 cargo zigbuild --release --target=$(TARGET_TRIPLE).$(GLIBC_VERSION)
 	cp "third-party/dufs/target/$(TARGET_TRIPLE)/release/dufs" "$(DIST_DIR)/.allium/bin/"
 
 SYNCTHING_VERSION := "v2.0.10"


### PR DESCRIPTION
Currently, make all fails on a Mac if you already have xz installed via homebrew - make tries to use Mac's lzma instead of building a proper Linux one:

```
mkdir -p dist
 rsync -a --exclude='.gitkeep' static/. dist
 cargo zigbuild --release --target=armv7-unknown-linux-gnueabihf.2.28 --features=miyoo --bin=alliumd --bin=allium-launcher --bin=activity-tracker --bin=screenshot-viewer
 --bin=screenshot --bin=say --bin=show --bin=myctl
     Finished release profile [optimized] target(s) in 0.50s
 patchelf
                 --replace-needed third-party/my283/usr/lib/libcam_os_wrapper.so libcam_os_wrapper.so
                 --replace-needed third-party/my283/usr/lib/libmi_sys.so libmi_sys.so
                 target/armv7-unknown-linux-gnueabihf/release/myctl
 mkdir -p dist/.allium/bin
 rsync -a target/armv7-unknown-linux-gnueabihf/release/alliumd dist/.allium/bin/
 rsync -a target/armv7-unknown-linux-gnueabihf/release/allium-launcher dist/.allium/bin/
 rsync -a target/armv7-unknown-linux-gnueabihf/release/screenshot dist/.tmp_update/bin/
 rsync -a target/armv7-unknown-linux-gnueabihf/release/say dist/.tmp_update/bin/
 rsync -a target/armv7-unknown-linux-gnueabihf/release/show dist/.tmp_update/bin/
 rsync -a target/armv7-unknown-linux-gnueabihf/release/activity-tracker "dist/Apps/Activity Tracker.pak/"
 rsync -a target/armv7-unknown-linux-gnueabihf/release/screenshot-viewer "dist/Apps/Screenshot Viewer.pak/"
 rsync -a target/armv7-unknown-linux-gnueabihf/release/myctl dist/.tmp_update/bin/
 cp "third-party/RetroArch-patch/bin/retroarch_miyoo354" "dist/RetroArch/retroarch"
 cd third-party/dufs && cargo zigbuild --release --target=armv7-unknown-linux-gnueabihf.2.28
    Compiling dufs v0.45.0 (/Users/ilembitov/Projects/allium/third-party/dufs)
 error: linking with /Users/ilembitov/Library/Caches/cargo-zigbuild/0.21.1/zigcc-armv7-unknown-linux-gnueabihf.2.28-5fb.sh failed: exit status: 1
   |
   = note:  "/Users/ilembitov/Library/Caches/cargo-zigbuild/0.21.1/zigcc-armv7-unknown-linux-gnueabihf.2.28-5fb.sh" "<1 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic"
 "/Users/ilembitov/Projects/allium/third-party/dufs/target/armv7-unknown-linux-gnueabihf/release/deps/rustcusSp4z/libring-e4f6d0d236bf0e05.rlib"
 "<sysroot>/lib/rustlib/armv7-unknown-linux-gnueabihf/lib/libcompiler_builtins-*.rlib" "-Wl,-Bdynamic" "-llzma" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L"
 "/Users/ilembitov/Projects/allium/third-party/dufs/target/armv7-unknown-linux-gnueabihf/release/deps/rustcusSp4z/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L"
 "/Users/ilembitov/Projects/allium/third-party/dufs/target/armv7-unknown-linux-gnueabihf/release/build/ring-a63d192ead1f9a01/out" "-L" "/opt/homebrew/Cellar/xz/5.8.3/lib" "-L"
 "<sysroot>/lib/rustlib/armv7-unknown-linux-gnueabihf/lib" "-o"
 "/Users/ilembitov/Projects/allium/third-party/dufs/target/armv7-unknown-linux-gnueabihf/release/deps/dufs-6bcc04fc1e415449" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now"
 "-Wl,-O1" "-Wl,--strip-all" "-nodefaultlibs"
   = note: some arguments are omitted. use --verbose to show all linker arguments
   = note: warning: ignoring deprecated linker optimization setting '1'
           error: unable to find dynamic system library 'lzma' using strategy 'no_fallback'. searched paths:
             /Users/ilembitov/Projects/allium/third-party/dufs/target/armv7-unknown-linux-gnueabihf/release/deps/rustcusSp4z/raw-dylibs/liblzma.so
             /Users/ilembitov/Projects/allium/third-party/dufs/target/armv7-unknown-linux-gnueabihf/release/build/ring-a63d192ead1f9a01/out/liblzma.so
             /opt/homebrew/Cellar/xz/5.8.3/lib/liblzma.so
             /Users/ilembitov/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/armv7-unknown-linux-gnueabihf/lib/liblzma.so

 error: could not compile dufs (bin "dufs") due to 1 previous error
 make: *** [dist/.allium/bin/dufs] Error 101
```

This fixes it