### PR TITLE
Enable NEON and VFPv4 compile flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,4 +2,4 @@
 rustflags = ["--cfg", "tokio_unstable"]
 
 [target.armv7-unknown-linux-gnueabihf]
-rustflags = ["-C", "target-cpu=cortex-a7"]
+rustflags = ["-C", "target-cpu=cortex-a7", "-C", "target-feature=+neon,+vfp4"]


### PR DESCRIPTION
They're both unstable in rust, but we're already on nightly so we might as well use them. `proc/cpuinfo` does list them both as supported on a MM+.

