### PR TITLE
Small build system improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,8 @@ debug: third-party/my283
 .PHONY: strip-all
 strip-all:
 	docker run --rm -i -v $(ROOT_DIR):/root/workspace $(TOOLCHAIN) \
-		find dist static migrations \
+		find dist \
 			-type f \
-			-not -path "static/.tmp_update/8188fu.ko" \
 			-not -path "dist/.tmp_update/8188fu.ko" \
 			-exec sh -c 'file "{}" | grep "not stripped"' \; \
 			-exec /opt/miyoomini-toolchain/usr/bin/arm-linux-gnueabihf-strip -s {} \;

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ all: dist build package-build $(DIST_DIR)/RetroArch/retroarch $(DIST_DIR)/.alliu
 .PHONY: clean
 clean:
 	rm -r $(DIST_DIR) || true
-	# Needs sudo because RetroArch build runs in docker as root
-	cd $(RETROARCH) && sudo make clean || true
+	cd $(RETROARCH) && make clean || true
 
 simulator-env: simulator/Themes
 	mkdir -p simulator
@@ -103,7 +102,7 @@ $(DIST_DIR)/RetroArch/retroarch: $(RETROARCH)/bin/retroarch_miyoo354
 	cp "$(RETROARCH)/bin/retroarch_miyoo354" "$(DIST_DIR)/RetroArch/retroarch"
 
 $(RETROARCH)/bin/retroarch_miyoo354:
-	docker run --rm -v /$(ROOT_DIR)/$(RETROARCH):/root/workspace $(TOOLCHAIN) bash -c "source /root/.bashrc; make all"
+	docker run --rm -v /$(ROOT_DIR)/$(RETROARCH):/root/workspace $(TOOLCHAIN) bash -c "source /root/.bashrc; make all; chown -R \$$(stat -c '%u:%g' /root/workspace) /root/workspace"
 
 $(DIST_DIR)/.allium/bin/dufs:
 	cd third-party/dufs && LZMA_API_STATIC=1 cargo zigbuild --release --target=$(TARGET_TRIPLE).$(GLIBC_VERSION)


### PR DESCRIPTION
This fixes two small annoyances I had with the build system:
- `make clean` required `sudo` because retroarch build artifacts were owned by root. The retroarch docker build now chowns build artifacts to the owner of the `RetroArch-patch` directory instead.
- `strip-all` was stripping files directly in `static/` and `migrations/`. Those files are git-tracked, so it would cause a bunch of spam in git. Binaries from `static/` get copied to `dist/` anyway, so only stripping `dist/` should be enough. 

One thing I'm not sure about is excluding migrations from `strip-all`. It currently changes nothing as all binaries in there seem to be pre-stripped, but they're zipped before being put in `dist/`, so any future unstripped binary in `migrations/` would ship unstripped with this PR.