### PR TITLE
Add dropbear ssh server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third-party/collie"]
 	path = third-party/collie
 	url = https://github.com/goweiwen/collie.git
+[submodule "third-party/dropbear/submodules/dropbear"]
+	path = third-party/dropbear/submodules/dropbear
+	url = https://github.com/mkj/dropbear.git

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ FEATURES ?=
 -include local.mk
 
 .PHONY: all
-all: dist build package-build $(DIST_DIR)/RetroArch/retroarch $(DIST_DIR)/.allium/bin/dufs $(DIST_DIR)/.allium/bin/collie $(DIST_DIR)/.allium/bin/syncthing $(DIST_DIR)/.allium/cores/drastic/drastic $(DIST_DIR)/Themes migrations strip-all
+all: dist build package-build $(DIST_DIR)/RetroArch/retroarch $(DIST_DIR)/.allium/bin/dufs $(DIST_DIR)/.allium/bin/collie $(DIST_DIR)/.allium/bin/dropbear $(DIST_DIR)/.allium/bin/syncthing $(DIST_DIR)/.allium/cores/drastic/drastic $(DIST_DIR)/Themes migrations strip-all
 
 .PHONY: clean
 clean:
@@ -119,6 +119,13 @@ $(DIST_DIR)/.allium/bin/syncthing:
 		wget "$(SYNCTHING_URL)" -O "$$TEMP_DIR/syncthing.tar.gz" && \
 		tar xf "$$TEMP_DIR/syncthing.tar.gz" --directory="$$TEMP_DIR" && \
 		mv "$$TEMP_DIR/syncthing-linux-arm-$(SYNCTHING_VERSION)/syncthing" "$(DIST_DIR)/.allium/bin/syncthing"
+
+DROPBEAR := third-party/dropbear
+$(DIST_DIR)/.allium/bin/dropbear:
+	docker run --rm -v $(ROOT_DIR)/$(DROPBEAR):/db:z $(TOOLCHAIN) bash -c \
+		'export PATH=/opt/miyoomini-toolchain/bin:$$PATH && cd /db && make clean && make'
+	mkdir -p $(DIST_DIR)/.allium/bin
+	cp $(DROPBEAR)/bin/dropbear $(DIST_DIR)/.allium/bin/dropbear
 
 DRASTIC_URL := https://github.com/steward-fu/nds/releases/download/v1.8/drastic-v1.8_miyoo.zip
 $(DIST_DIR)/.allium/cores/drastic/drastic:

--- a/crates/allium-launcher/src/view/settings/wifi.rs
+++ b/crates/allium-launcher/src/view/settings/wifi.rs
@@ -87,6 +87,7 @@ impl Wifi {
                 locale.t("settings-wifi-ntp-enabled"),
                 locale.t("settings-wifi-web-file-explorer"),
                 locale.t("settings-wifi-telnet-enabled"),
+                locale.t("settings-wifi-ssh-enabled"),
                 locale.t("settings-wifi-ftp-enabled"),
                 locale.t("settings-wifi-scraper"),
                 locale.t("settings-wifi-syncthing"),
@@ -124,6 +125,7 @@ impl Wifi {
                     settings.telnet,
                     Alignment::Right,
                 )),
+                Box::new(Toggle::new(Point::zero(), settings.ssh, Alignment::Right)),
                 Box::new(Toggle::new(Point::zero(), settings.ftp, Alignment::Right)),
                 Box::new(Toggle::new(
                     Point::zero(),
@@ -311,8 +313,9 @@ impl View for Wifi {
                             }
                         }
                         6 => self.settings.toggle_telnet(val.as_bool().unwrap())?,
-                        7 => self.settings.toggle_ftp(val.as_bool().unwrap())?,
-                        8 => {
+                        7 => self.settings.toggle_ssh(val.as_bool().unwrap())?,
+                        8 => self.settings.toggle_ftp(val.as_bool().unwrap())?,
+                        9 => {
                             let enabled = val.as_bool().unwrap();
                             self.settings.toggle_scraper(enabled)?;
                             if enabled {
@@ -343,7 +346,7 @@ impl View for Wifi {
                                 commands.send(Command::DismissToast).await.ok();
                             }
                         }
-                        9 => {
+                        10 => {
                             let enabled = val.as_bool().unwrap();
                             self.settings.toggle_syncthing(enabled)?;
                             if enabled {

--- a/crates/common/src/wifi.rs
+++ b/crates/common/src/wifi.rs
@@ -18,6 +18,8 @@ pub struct WiFiSettings {
     pub ntp: bool,
     pub web_file_browser: bool,
     pub telnet: bool,
+    #[serde(default)]
+    pub ssh: bool,
     pub ftp: bool,
     pub syncthing: bool,
     pub scraper: bool,
@@ -32,6 +34,7 @@ impl WiFiSettings {
             ntp: false,
             web_file_browser: false,
             telnet: false,
+            ssh: false,
             ftp: false,
             syncthing: false,
             scraper: false,
@@ -56,6 +59,7 @@ impl WiFiSettings {
         if self.wifi {
             wifi_on()?;
             telnet_off()?;
+            ssh_off()?;
             if self.ntp {
                 info!("Starting NTP...");
                 ntp_sync()?;
@@ -63,6 +67,10 @@ impl WiFiSettings {
             if self.telnet {
                 info!("Starting Telnet...");
                 telnet_on()?;
+            }
+            if self.ssh {
+                info!("Starting SSH...");
+                ssh_on()?;
             }
             if self.ftp {
                 info!("Starting FTP...");
@@ -144,11 +152,15 @@ network={{
         if self.wifi {
             wifi_on()?;
             let telnet = self.telnet;
+            let ssh = self.ssh;
             let ftp = self.ftp;
             tokio::spawn(async move {
                 if wait_for_wifi().await.is_ok() {
                     if telnet {
                         telnet_on().ok();
+                    }
+                    if ssh {
+                        ssh_on().ok();
                     }
                     if ftp {
                         ftp_on().ok();
@@ -159,6 +171,9 @@ network={{
             wifi_off()?;
             if self.telnet {
                 telnet_off().ok();
+            }
+            if self.ssh {
+                ssh_off().ok();
             }
             if self.ftp {
                 ftp_off().ok();
@@ -207,6 +222,16 @@ network={{
             telnet_on()?;
         } else {
             telnet_off()?;
+        }
+        Ok(())
+    }
+
+    pub fn toggle_ssh(&mut self, enabled: bool) -> Result<()> {
+        self.ssh = enabled;
+        if self.ssh {
+            ssh_on()?;
+        } else {
+            ssh_off()?;
         }
         Ok(())
     }
@@ -322,6 +347,46 @@ pub fn telnet_off() -> Result<()> {
             .await
             .map_err(|e| {
                 log::error!("telnet-off.sh failed: {}", e);
+                e
+            })
+    });
+    Ok(())
+}
+
+pub fn ssh_on() -> Result<()> {
+    #[cfg(feature = "miyoo")]
+    tokio::spawn(async {
+        Command::new(crate::constants::ALLIUM_SCRIPTS_DIR.join("ssh-on.sh"))
+            .spawn()
+            .map_err(|e| {
+                log::error!("failed to spawn ssh-on.sh: {}", e);
+                e
+            })
+            .unwrap()
+            .wait()
+            .await
+            .map_err(|e| {
+                log::error!("ssh-on.sh failed: {}", e);
+                e
+            })
+    });
+    Ok(())
+}
+
+pub fn ssh_off() -> Result<()> {
+    #[cfg(feature = "miyoo")]
+    tokio::spawn(async {
+        Command::new(crate::constants::ALLIUM_SCRIPTS_DIR.join("ssh-off.sh"))
+            .spawn()
+            .map_err(|e| {
+                log::error!("failed to spawn ssh-off.sh: {}", e);
+                e
+            })
+            .unwrap()
+            .wait()
+            .await
+            .map_err(|e| {
+                log::error!("ssh-off.sh failed: {}", e);
                 e
             })
     });

--- a/static/.allium/etc/passwd
+++ b/static/.allium/etc/passwd
@@ -1,0 +1,1 @@
+root::0:0:Linux User,,,:/mnt/SDCARD:/bin/sh

--- a/static/.allium/locales/en-US/main.ftl
+++ b/static/.allium/locales/en-US/main.ftl
@@ -43,6 +43,7 @@ settings-wifi-wifi-password = Wi-Fi Password
 settings-wifi-ntp-enabled = NTP Enabled
 settings-wifi-web-file-explorer = Web File Explorer
 settings-wifi-telnet-enabled = Telnet Enabled
+settings-wifi-ssh-enabled = SSH Enabled
 settings-wifi-ftp-enabled = FTP Enabled
 settings-wifi-scraper = Scraper
 settings-wifi-syncthing = Syncthing Enabled

--- a/static/.allium/scripts/ssh-off.sh
+++ b/static/.allium/scripts/ssh-off.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+killall dropbear
+# Restore the original read-only /etc/passwd.
+umount /etc/passwd 2>/dev/null

--- a/static/.allium/scripts/ssh-on.sh
+++ b/static/.allium/scripts/ssh-on.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+dir=$(dirname "$0")
+if "$dir"/wait-for-wifi.sh; then
+    mkdir -p "$ROOT/.allium/state/dropbear"
+    # Bind-mount a /etc/passwd with a blank-password root.
+    # That lets stock `dropbear -B` allow passwordless login.
+    if ! mount | grep -q " /etc/passwd "; then
+        mount -o bind "$ROOT/.allium/etc/passwd" /etc/passwd
+    fi
+    "$ROOT/.allium/bin/dropbear" -R -B -p 22 >/dev/null 2>&1
+    exit 0
+fi
+
+exit 1

--- a/third-party/dropbear/.gitignore
+++ b/third-party/dropbear/.gitignore
@@ -1,0 +1,2 @@
+build/
+bin/

--- a/third-party/dropbear/Makefile
+++ b/third-party/dropbear/Makefile
@@ -1,0 +1,63 @@
+SUBMODULE_DIR = submodules/dropbear
+BUILD_DIR = build
+SRC_DIR = src
+PATCH_DIR = patches
+BIN_DIR = bin
+
+CONFIGURE_FLAGS ?= --host=arm-linux-gnueabihf --disable-zlib --disable-harden \
+	--disable-pam --disable-syslog --disable-shadow --disable-lastlog \
+	--disable-utmp --disable-utmpx --disable-wtmp --disable-wtmpx \
+	--disable-loginfunc --disable-pututline --disable-pututxline
+
+# libutil static (device lacks libutil.so.1), libc/libcrypt dynamic.
+DROPBEAR_LIBS ?= -Wl,-Bstatic -lutil -Wl,-Bdynamic -lcrypt
+
+.PHONY: all build copy-submodule apply-patches assemble clean
+
+all: build
+
+## Submodule management
+
+$(BUILD_DIR)/.has_submodule:
+	@if [ -d "$(SUBMODULE_DIR)" ] && [ -z "$$(ls -A $(SUBMODULE_DIR))" ]; then \
+		git submodule update --init --recursive; \
+	fi
+	mkdir -p $(BUILD_DIR)
+	cp -r $(SUBMODULE_DIR)/* $(BUILD_DIR)/
+	@touch $(BUILD_DIR)/.has_submodule
+
+copy-submodule: $(BUILD_DIR)/.has_submodule
+
+## Patch management
+
+$(BUILD_DIR)/.is_patched: $(BUILD_DIR)/.has_submodule
+	@for patch in $$(ls $(PATCH_DIR)/*.patch 2>/dev/null | sort); do \
+		echo "Applying $$patch"; \
+		patch -d $(BUILD_DIR) -p1 < $$patch; \
+	done
+	@touch $(BUILD_DIR)/.is_patched
+
+apply-patches: $(BUILD_DIR)/.is_patched
+
+## Source management
+
+$(BUILD_DIR)/.is_assembled: $(BUILD_DIR)/.is_patched
+	cp -r $(SRC_DIR)/* $(BUILD_DIR)/
+	@touch $(BUILD_DIR)/.is_assembled
+
+assemble: $(BUILD_DIR)/.is_assembled
+
+## Build targets
+
+$(BIN_DIR)/dropbear: $(BUILD_DIR)/.is_assembled
+	cd $(BUILD_DIR) && sh configure $(CONFIGURE_FLAGS)
+	cd $(BUILD_DIR) && $(MAKE) PROGRAMS=dropbear LIBS="$(DROPBEAR_LIBS)"
+	mkdir -p $(BIN_DIR)
+	cp $(BUILD_DIR)/dropbear $(BIN_DIR)/dropbear
+
+build: $(BIN_DIR)/dropbear
+
+## Clean everything
+
+clean:
+	rm -rf $(BUILD_DIR) $(BIN_DIR) || true

--- a/third-party/dropbear/patches/00001_no_login_shell.patch
+++ b/third-party/dropbear/patches/00001_no_login_shell.patch
@@ -1,0 +1,12 @@
+--- a/src/dbutil.c
++++ b/src/dbutil.c
+@@ -374,7 +374,8 @@ void run_shell_command(const char* cmd, unsigned int maxfd, char* usershell) {
+
+ 	baseshell = basename(usershell);
+
+-	if (cmd != NULL) {
++	/* Allium: skip login shell */
++	if (IS_DROPBEAR_SERVER || cmd != NULL) {
+ 		argv[0] = baseshell;
+ 	} else {
+ 		/* a login shell should be "-bash" for "/bin/bash" etc */

--- a/third-party/dropbear/src/localoptions.h
+++ b/third-party/dropbear/src/localoptions.h
@@ -1,0 +1,4 @@
+/* Make the auto-generated host keys (dropbear -R) be written to the SD card*/
+#define ED25519_PRIV_FILENAME "/mnt/SDCARD/.allium/state/dropbear/ed25519_host_key"
+#define RSA_PRIV_FILENAME "/mnt/SDCARD/.allium/state/dropbear/rsa_host_key"
+#define ECDSA_PRIV_FILENAME "/mnt/SDCARD/.allium/state/dropbear/ecdsa_host_key"


### PR DESCRIPTION
This adds an SSH server powered by dropbear, and a UI toggle to enable it. It's currently very basic, using a passwordless login and dropping you straight into a root session. But I still think it's nicer than telnet :)

I essentially copied the way OnionOS manages passwordless logins: we temporarily bind-mount a blank-password `/etc/passwd` over the read-only firmware one while dropbear runs (reverted when SSH is toggled off).
