### PR TITLE
fix: cleanly unmount SD card before shutdown

### DIFF
--- a/crates/common/src/platform/miyoo/mod.rs
+++ b/crates/common/src/platform/miyoo/mod.rs
@@ -8,7 +8,6 @@ mod volume;
 use std::fmt;
 use std::fs::File;
 use std::io::Write;
-use std::os::unix::process::CommandExt;
 use std::process::Command;
 
 use anyhow::Result;
@@ -84,17 +83,9 @@ impl Platform for MiyooPlatform {
 
     fn shutdown(&self) -> Result<()> {
         #[cfg(unix)]
-        {
-            std::process::Command::new("sync").spawn()?.wait()?;
-            match self.model {
-                MiyooDeviceModel::Miyoo283 => {
-                    let _ = std::process::Command::new("reboot").exec();
-                }
-                MiyooDeviceModel::Miyoo285 | MiyooDeviceModel::Miyoo354 => {
-                    let _ = std::process::Command::new("poweroff").exec();
-                }
-            }
-        }
+        std::process::exit(64);
+
+        #[cfg(not(unix))]
         Ok(())
     }
 

--- a/static/.tmp_update/script/clean-shutdown.sh
+++ b/static/.tmp_update/script/clean-shutdown.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+model="$1"
+root=/mnt/SDCARD
+log_file=/tmp/allium-clean-shutdown.log
+
+# Release inherited logging pipes before stopping processes such as tee.
+exec </dev/null >"$log_file" 2>&1
+cd /
+unset LD_PRELOAD
+export PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+echo "=== clean shutdown started ==="
+date
+
+# Swap must be disabled before its backing file can be unmounted.
+swapoff "$root/cachefile" 2>/dev/null || true
+
+# Stop services using executables, working directories, or data on the card.
+for service in collie dufs ftp ssh syncthing telnet; do
+    script="$root/.allium/scripts/$service-off.sh"
+    [ -f "$script" ] && /bin/sh "$script" 2>/dev/null || true
+done
+
+"$root/.tmp_update/script/stop_audioserver.sh" 2>/dev/null || true
+
+sync
+
+# Stop any remaining process that still references the SD filesystem.
+for process_id in $(fuser -m "$root" 2>/dev/null); do
+    [ "$process_id" = "$$" ] || kill "$process_id" 2>/dev/null || true
+done
+
+sleep 1
+
+for process_id in $(fuser -m "$root" 2>/dev/null); do
+    [ "$process_id" = "$$" ] || kill -9 "$process_id" 2>/dev/null || true
+done
+
+# SSH bind-mounts this file from the SD card.
+umount /etc/passwd 2>/dev/null || true
+
+sync
+
+if ! umount "$root"; then
+    echo "failed to unmount $root; refusing to power off"
+    exit 1
+fi
+
+if grep -q '/dev/mmcblk0p1' /proc/mounts; then
+    echo "sd card remains mounted; refusing to power off"
+    grep '/dev/mmcblk0p1' /proc/mounts
+    exit 1
+fi
+
+echo "sd card cleanly unmounted"
+sync
+
+case "$model" in
+    283)
+        exec /sbin/reboot
+        ;;
+    285|354)
+        exec /sbin/poweroff
+        ;;
+    *)
+        echo "unknown miyoo model: $model"
+        exit 1
+        ;;
+esac

--- a/static/.tmp_update/updater
+++ b/static/.tmp_update/updater
@@ -78,8 +78,19 @@ for script in "$ROOT"/.allium/migrations/*; do
 done
 show -c
 
+# Copy the final shutdown stage to RAM before starting Allium.
+shutdown_helper=/tmp/allium-clean-shutdown
+cp "$ROOT"/.tmp_update/script/clean-shutdown.sh "$shutdown_helper"
+chmod 700 "$shutdown_helper"
+
 # run Allium
 RUST_LOG=info "$ROOT"/.allium/bin/alliumd >"$ROOT"/allium.log 2>&1
+allium_status=$?
+
+# Exit code 64 means Allium completed its state-saving shutdown path.
+if [ "$allium_status" -eq 64 ]; then
+    exec /bin/sh "$shutdown_helper" "$MODEL"
+fi
 
 if [ -f "$ROOT"/.debug ]; then
     "$ROOT"/.allium/scripts/wifi-on.sh


### PR DESCRIPTION
## what this fixes

on my Miyoo Mini Plus, a normal Allium shutdown consistently left the SD card marked dirty in Windows.

stock v1.0.1:

```text
Volume - I: is Dirty
```

after applying this patch directly on top of v1.0.1:

```text
Volume - I: is NOT Dirty
```

Windows’ repair tool cleared the dirty flag, but another normal shutdown on stock v1.0.1 set it again.

## what changed

the shutdown path now unmounts `/mnt/SDCARD` before calling the final poweroff or reboot command.

the helper runs from `/tmp`, stops processes still using the card, unmounts the `/etc/passwd` bind mount, unmounts the SD card, verifies that it is no longer mounted, and only then powers off.

## tested

- Miyoo Mini Plus
- stable v1.0.1 with only this patch applied
- repeated shutdown and boot cycles
- quick power-on after shutdown
- `chkdsk I:` completed and reported no filesystem problems
- `fsutil dirty query I:` reported `NOT Dirty`
- `cargo fmt --all -- --check`
- `cargo check --all-targets`
- shell syntax checks
- release ARM build and package creation