### PR TITLE
fix: directly write mute status into linux proc

### DIFF
--- a/crates/myctl/src/volume.rs
+++ b/crates/myctl/src/volume.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use anyhow::Result;
 
 const MIN_RAW_VALUE: i32 = -60;
@@ -12,9 +13,9 @@ pub fn set(volume: i32) -> Result<()> {
     unsafe { ffi::MI_AO_SetVolume(0, volume) };
 
     if prev_volume <= MIN_RAW_VALUE && volume > MIN_RAW_VALUE {
-        unsafe { ffi::MI_AO_SetMute(0, false as u8) };
+        fs::write("/proc/mi_modules/mi_ao/mi_ao0", "set_ao_mute 0")?;
     } else if prev_volume > MIN_RAW_VALUE && volume <= MIN_RAW_VALUE {
-        unsafe { ffi::MI_AO_SetMute(0, true as u8) };
+        fs::write("/proc/mi_modules/mi_ao/mi_ao0", "set_ao_mute 1")?;
     }
 
     Ok(())

--- a/crates/myctl/src/volume.rs
+++ b/crates/myctl/src/volume.rs
@@ -1,5 +1,5 @@
-use std::fs;
 use anyhow::Result;
+use std::fs;
 
 const MIN_RAW_VALUE: i32 = -60;
 const MAX_RAW_VALUE: i32 = 0;


### PR DESCRIPTION
## Context

- Issue: https://github.com/goweiwen/Allium/issues/128

Sound is not completely muted after pushing multiple times `vol -` on my Miyoo Mini Flip.

## Changes

I'm sending linux (un)mute commands directly to proc instead of going through the SDK.

### Tested on

- Device: Miyoo Mini Flip ✅
- Allium version: v1.0.1 + last nightly changes

### Investigation notes

Before the fix, `allium.log`: 
```
INFO  [alliumd::alliumd] setting volume: 5
...
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
CamOsRwsemDownRead not inited, LR:0x0056CFF7
CamOsRwsemUpRead not inited, LR:0x0056D123
[1;31m[MI ERR ]: MI_AO_SetMute[4539]: Dev0 has not been enabled.
[0mINFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
INFO  [alliumd::alliumd] adding volume: -1
...
INFO  [alliumd::alliumd] main process terminated, recording play time
INFO  [allium_launcher::allium_launcher] goodbye from allium launcher
```

The `MI_AO_SetMute` call does not work. It's defined in the [SDK docs](https://wx.comake.online/doc/d8clf27cnes2-SSD20X/customer/development/mi/en/mi_ao.html#216-mi_ao_setmute) and in the FFI bindings, but the bindings are defined for [`my283` (Miyoo Mini)](https://github.com/goweiwen/Allium/tree/main/third-party/my283) and not for `my285` (Miyoo Mini Flip).

After the fix:
- the `MI_AO_SetMute` error is not written in the logs
- sound is correctly muted when low enough, and unmuted when up again ✅