### PR TITLE
feat: volume on startup setting (muted or restore)

### DIFF
--- a/crates/allium-launcher/src/view/settings/power.rs
+++ b/crates/allium-launcher/src/view/settings/power.rs
@@ -9,7 +9,7 @@ use common::display::Display as DisplayTrait;
 use common::geom::{Alignment, Point, Rect};
 use common::locale::Locale;
 use common::platform::{DefaultPlatform, Key, KeyEvent, Platform};
-use common::power::{PowerButtonAction, PowerSettings};
+use common::power::{PowerButtonAction, PowerSettings, VolumeOnStartup};
 use common::resources::Resources;
 use common::stylesheet::Stylesheet;
 use common::view::{ButtonHint, ButtonHints, Number, Select, SettingsList, Toggle, View};
@@ -85,6 +85,18 @@ impl Power {
                             x.to_string()
                         }
                     },
+                    Alignment::Right,
+                )),
+            ),
+            (
+                locale.t("settings-power-volume-on-startup"),
+                Box::new(Select::new(
+                    Point::zero(),
+                    power_settings.volume_on_startup as usize,
+                    vec![
+                        locale.t("settings-power-volume-on-startup-restore"),
+                        locale.t("settings-power-volume-on-startup-muted"),
+                    ],
                     Alignment::Right,
                 )),
             ),
@@ -205,12 +217,18 @@ impl View for Power {
                             toast_needs_restart_for_effect(&self.res, &commands).await?;
                         }
                         2 => {
+                            self.power_settings.volume_on_startup =
+                                VolumeOnStartup::from_repr(val.as_int().unwrap() as usize)
+                                    .unwrap_or_default();
+                            toast_needs_restart_for_effect(&self.res, &commands).await?;
+                        }
+                        3 => {
                             self.power_settings.power_button_action =
                                 PowerButtonAction::from_repr(val.as_int().unwrap() as usize)
                                     .unwrap_or_default();
                             toast_needs_restart_for_effect(&self.res, &commands).await?;
                         }
-                        3 => {
+                        4 => {
                             self.power_settings.lid_close_action =
                                 PowerButtonAction::from_repr(val.as_int().unwrap() as usize)
                                     .unwrap_or_default();

--- a/crates/alliumd/src/alliumd.rs
+++ b/crates/alliumd/src/alliumd.rs
@@ -173,7 +173,7 @@ impl AlliumD<DefaultPlatform> {
         common::platform::miyoo::try_fix_resolution().await?;
 
         let mut platform = DefaultPlatform::new()?;
-        let state = AlliumDState::load()?;
+        let mut state = AlliumDState::load()?;
 
         let mut keys = EnumMap::default();
 
@@ -200,8 +200,8 @@ impl AlliumD<DefaultPlatform> {
         }
 
         if keys[Key::VolDown] {
-            info!("volume down key held at startup, setting volume to 0");
-            platform.set_volume(0)?;
+            info!("volume down key held at startup, muting");
+            state.volume = 0;
         }
 
         info!("setting volume: {}", state.volume);

--- a/crates/alliumd/src/alliumd.rs
+++ b/crates/alliumd/src/alliumd.rs
@@ -15,7 +15,7 @@ use common::constants::{
 };
 use common::display::settings::DisplaySettings;
 use common::locale::{Locale, LocaleSettings};
-use common::power::{PowerButtonAction, PowerSettings};
+use common::power::{PowerButtonAction, PowerSettings, VolumeOnStartup};
 use common::retroarch::RetroArchCommand;
 use common::wifi::WiFiSettings;
 use enum_map::EnumMap;
@@ -199,10 +199,20 @@ impl AlliumD<DefaultPlatform> {
             GameInfo::delete()?;
         }
 
-        if keys[Key::VolDown] {
+        let power_settings = PowerSettings::load()?;
+
+        state.volume = if keys[Key::VolDown] {
             info!("volume down key held at startup, muting");
-            state.volume = 0;
-        }
+            0
+        } else {
+            match power_settings.volume_on_startup {
+                VolumeOnStartup::Muted => {
+                    info!("volume on startup is muted");
+                    0
+                }
+                VolumeOnStartup::Restore => state.volume,
+            }
+        };
 
         info!("setting volume: {}", state.volume);
         platform.set_volume(state.volume)?;
@@ -215,7 +225,6 @@ impl AlliumD<DefaultPlatform> {
 
         let main = spawn_main().await?;
         let locale = Locale::new(&LocaleSettings::load()?.lang);
-        let power_settings = PowerSettings::load()?;
 
         // Spawn the persistent menu thread at startup
         let menu = MenuHandle::new();

--- a/crates/common/src/power.rs
+++ b/crates/common/src/power.rs
@@ -13,6 +13,8 @@ pub struct PowerSettings {
     pub lid_close_action: PowerButtonAction,
     pub auto_sleep_when_charging: bool,
     pub auto_sleep_duration_minutes: i32,
+    #[serde(default)]
+    pub volume_on_startup: VolumeOnStartup,
 }
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, FromRepr, Default)]
@@ -21,6 +23,15 @@ pub enum PowerButtonAction {
     Suspend,
     Shutdown,
     Nothing,
+}
+
+/// What the volume is set to when the device powers on.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, FromRepr, Default)]
+pub enum VolumeOnStartup {
+    /// Restore the volume the device was turned off at.
+    #[default]
+    Restore,
+    Muted,
 }
 
 impl PowerButtonAction {
@@ -42,6 +53,7 @@ impl Default for PowerSettings {
             power_button_action: PowerButtonAction::Suspend,
             auto_sleep_when_charging: true,
             auto_sleep_duration_minutes: 5,
+            volume_on_startup: VolumeOnStartup::Restore,
         }
     }
 }

--- a/static/.allium/locales/de-DE/main.ftl
+++ b/static/.allium/locales/de-DE/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = Aktion bei Deckel
 settings-power-auto-sleep-when-charging = Auto-Schlaf beim Laden
 settings-power-auto-sleep-duration-minutes = Auto-Schlaf Dauer (Min)
 settings-power-auto-sleep-duration-disabled = Deaktiviert
+settings-power-volume-on-startup = Lautstärke beim Start
+settings-power-volume-on-startup-restore = Wiederherstellen
+settings-power-volume-on-startup-muted = Stumm
 
 settings-files = Dateien
 

--- a/static/.allium/locales/en-US/main.ftl
+++ b/static/.allium/locales/en-US/main.ftl
@@ -128,6 +128,9 @@ settings-power-lid-close-action = Lid Close Action
 settings-power-auto-sleep-when-charging = Auto Sleep When Charging
 settings-power-auto-sleep-duration-minutes = Auto Sleep Duration (Minutes)
 settings-power-auto-sleep-duration-disabled = Disabled
+settings-power-volume-on-startup = Volume on Startup
+settings-power-volume-on-startup-restore = Restore
+settings-power-volume-on-startup-muted = Muted
 
 settings-files = Files
 

--- a/static/.allium/locales/es-ES/main.ftl
+++ b/static/.allium/locales/es-ES/main.ftl
@@ -99,6 +99,9 @@ settings-power-lid-close-action = Acción de la Tapa
 settings-power-auto-sleep-when-charging = Auto Suspensión al Cargar
 settings-power-auto-sleep-duration-minutes = Duración Auto Suspensión (Minutos)
 settings-power-auto-sleep-duration-disabled = Deshabilitado
+settings-power-volume-on-startup = Volumen al Iniciar
+settings-power-volume-on-startup-restore = Restaurar
+settings-power-volume-on-startup-muted = Silenciado
 
 settings-files = Archivos
 

--- a/static/.allium/locales/es-LA/main.ftl
+++ b/static/.allium/locales/es-LA/main.ftl
@@ -99,6 +99,9 @@ settings-power-lid-close-action = Acción de la Tapa
 settings-power-auto-sleep-when-charging = Auto Suspensión al Cargar
 settings-power-auto-sleep-duration-minutes = Duración Auto Suspensión (Minutos)
 settings-power-auto-sleep-duration-disabled = Deshabilitado
+settings-power-volume-on-startup = Volumen al Iniciar
+settings-power-volume-on-startup-restore = Restaurar
+settings-power-volume-on-startup-muted = Silenciado
 
 settings-files = Archivos
 

--- a/static/.allium/locales/fr-FR/main.ftl
+++ b/static/.allium/locales/fr-FR/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = Action couvercle
 settings-power-auto-sleep-when-charging = Veille auto lors de la charge
 settings-power-auto-sleep-duration-minutes = Durée veille auto (min)
 settings-power-auto-sleep-duration-disabled = Désactivé
+settings-power-volume-on-startup = Volume au démarrage
+settings-power-volume-on-startup-restore = Restaurer
+settings-power-volume-on-startup-muted = Muet
 
 settings-files = Fichiers
 

--- a/static/.allium/locales/id-ID/main.ftl
+++ b/static/.allium/locales/id-ID/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = Aksi tutup
 settings-power-auto-sleep-when-charging = Tidur otomatis saat isi daya
 settings-power-auto-sleep-duration-minutes = Durasi tidur otomatis (min)
 settings-power-auto-sleep-duration-disabled = Dinonaktifkan
+settings-power-volume-on-startup = Volume saat mulai
+settings-power-volume-on-startup-restore = Pulihkan
+settings-power-volume-on-startup-muted = Bisu
 
 settings-files = Berkas
 

--- a/static/.allium/locales/it-IT/main.ftl
+++ b/static/.allium/locales/it-IT/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = Azione chiusura lid
 settings-power-auto-sleep-when-charging = Auto sospensione in ricarica
 settings-power-auto-sleep-duration-minutes = Durata auto sospensione (min)
 settings-power-auto-sleep-duration-disabled = Disabilitato
+settings-power-volume-on-startup = Volume all'avvio
+settings-power-volume-on-startup-restore = Ripristina
+settings-power-volume-on-startup-muted = Muto
 
 settings-files = File
 

--- a/static/.allium/locales/ja-JP/main.ftl
+++ b/static/.allium/locales/ja-JP/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = 蓋を閉じる動作
 settings-power-auto-sleep-when-charging = 充電中の自動スリープ
 settings-power-auto-sleep-duration-minutes = 自動スリープ時間（分）
 settings-power-auto-sleep-duration-disabled = 無効
+settings-power-volume-on-startup = 起動時の音量
+settings-power-volume-on-startup-restore = 復元
+settings-power-volume-on-startup-muted = ミュート
 
 settings-files = ファイル
 

--- a/static/.allium/locales/ro-RO/main.ftl
+++ b/static/.allium/locales/ro-RO/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = Acțiune închidere capac
 settings-power-auto-sleep-when-charging = Somn automat la încărcare
 settings-power-auto-sleep-duration-minutes = Durată somn automat (min)
 settings-power-auto-sleep-duration-disabled = Dezactivat
+settings-power-volume-on-startup = Volum la pornire
+settings-power-volume-on-startup-restore = Restaurare
+settings-power-volume-on-startup-muted = Fără sonor
 
 settings-files = Fișiere
 

--- a/static/.allium/locales/zh-CN/main.ftl
+++ b/static/.allium/locales/zh-CN/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = 合盖操作
 settings-power-auto-sleep-when-charging = 充电时自动休眠
 settings-power-auto-sleep-duration-minutes = 自动休眠时长（分钟）
 settings-power-auto-sleep-duration-disabled = 已禁用
+settings-power-volume-on-startup = 启动时音量
+settings-power-volume-on-startup-restore = 恢复
+settings-power-volume-on-startup-muted = 静音
 
 settings-files = 文件
 

--- a/static/.allium/locales/zh-HK/main.ftl
+++ b/static/.allium/locales/zh-HK/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = 合蓋操作
 settings-power-auto-sleep-when-charging = 充電時自動瞓覺
 settings-power-auto-sleep-duration-minutes = 自動瞓覺時長（分鐘）
 settings-power-auto-sleep-duration-disabled = 已停用
+settings-power-volume-on-startup = 開機音量
+settings-power-volume-on-startup-restore = 還原
+settings-power-volume-on-startup-muted = 靜音
 
 settings-files = 文件
 

--- a/static/.allium/locales/zh-TW/main.ftl
+++ b/static/.allium/locales/zh-TW/main.ftl
@@ -98,6 +98,9 @@ settings-power-lid-close-action = 合蓋操作
 settings-power-auto-sleep-when-charging = 充電時自動休眠
 settings-power-auto-sleep-duration-minutes = 自動休眠時長（分鐘）
 settings-power-auto-sleep-duration-disabled = 已禁用
+settings-power-volume-on-startup = 開機音量
+settings-power-volume-on-startup-restore = 還原
+settings-power-volume-on-startup-muted = 靜音
 
 settings-files = 文件
 


### PR DESCRIPTION
Closes #117

Adds `Volume on Startup: Restore / Muted` to Power settings, as was sketched in the issue.
Also fixes muting on volume held down:  `platform.set_volume(0)` was  followed one line later by an unconditional  `platform.set_volume(state.volume)?`, so holding volume down had no effect.