### PR TITLE
Add indicators for volume and brightness

### DIFF
--- a/crates/allium-launcher/src/allium_launcher.rs
+++ b/crates/allium-launcher/src/allium_launcher.rs
@@ -86,7 +86,7 @@ impl AlliumLauncher<DefaultPlatform> {
         let mut keys: EnumMap<Key, bool> = EnumMap::default();
 
         #[cfg(not(feature = "debug-ui"))]
-        let mut frame_interval = tokio::time::interval(tokio::time::Duration::from_micros(166_667));
+        let mut frame_interval = tokio::time::interval(common::constants::UI_FRAME_INTERVAL);
         #[cfg(feature = "debug-ui")]
         let mut frame_interval = tokio::time::interval(tokio::time::Duration::from_secs(86400));
 

--- a/crates/allium-launcher/src/entry/app.rs
+++ b/crates/allium-launcher/src/entry/app.rs
@@ -46,7 +46,8 @@ impl App {
         };
 
         let name = config.label;
-        let image = config.icon;
+        // config.json states the icon relative to the pak, as the launch script
+        let image = config.icon.map(|icon| directory.join(icon));
         let command = directory.join(config.launch);
 
         Ok(Self {

--- a/crates/allium-launcher/src/view/app.rs
+++ b/crates/allium-launcher/src/view/app.rs
@@ -340,8 +340,8 @@ where
                 if self.tabs.should_draw() && styles.ui.tabs_backdrop_color.a() > 0 {
                     let mut bbox = self.tabs.bounding_box(styles);
                     if bbox.w > 0 && bbox.h > 0 {
-                        let padding_x = styles.ui.padding_x as i32;
-                        let padding_y = styles.ui.padding_y as i32;
+                        let padding_x = styles.ui.padding_x;
+                        let padding_y = styles.ui.padding_y;
                         bbox.x -= padding_x;
                         bbox.y -= padding_y;
                         bbox.w += (padding_x * 2) as u32;

--- a/crates/allium-launcher/src/view/settings/theme.rs
+++ b/crates/allium-launcher/src/view/settings/theme.rs
@@ -40,10 +40,11 @@ impl Theme {
     pub fn new(rect: Rect, res: Resources, state: Option<ChildState>) -> Self {
         let Rect { x, y, w, .. } = rect;
 
-        let stylesheet = Stylesheet::load().unwrap();
-
         let locale = res.get::<Locale>();
         let styles = res.get::<Stylesheet>();
+
+        // The res copy mirrors disk (resynced on ReloadStylesheet), so skip a second load
+        let stylesheet = (*styles).clone();
 
         let context = ThemeContext {
             fonts: StylesheetFont::available_fonts().unwrap_or_default(),

--- a/crates/allium-menu/Cargo.toml
+++ b/crates/allium-menu/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 [features]
 simulator = ["common/simulator"]
 miyoo = ["common/miyoo"]
-debug-ui = []
+debug-ui = ["common/debug-ui"] # Draw bounding boxes
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/allium-menu/src/allium_menu.rs
+++ b/crates/allium-menu/src/allium_menu.rs
@@ -33,7 +33,7 @@ where
 }
 
 impl AlliumMenu<DefaultPlatform> {
-    pub async fn new(mut platform: DefaultPlatform) -> Result<Self> {
+    pub async fn new(mut platform: DefaultPlatform, styles: Stylesheet) -> Result<Self> {
         let display = platform.display()?;
         let battery = platform.battery()?;
         let rect = display.bounding_box();
@@ -41,7 +41,7 @@ impl AlliumMenu<DefaultPlatform> {
         let mut res = TypeMap::new();
         res.insert(Database::new()?);
         res.insert(GameInfo::load()?.unwrap_or_default());
-        res.insert(Stylesheet::load()?);
+        res.insert(styles);
         res.insert(Locale::new(&LocaleSettings::load()?.lang));
         res.insert(Into::<geom::Size>::into(display.size()));
         let res = Resources::new(res);

--- a/crates/allium-menu/src/main.rs
+++ b/crates/allium-menu/src/main.rs
@@ -9,6 +9,7 @@ use allium_menu::{AlliumMenu, RetroArchInfo};
 use common::{
     platform::{DefaultPlatform, Platform},
     retroarch::RetroArchCommand,
+    stylesheet::Stylesheet,
 };
 use simple_logger::SimpleLogger;
 
@@ -44,7 +45,7 @@ async fn main() -> Result<()> {
     }
 
     let platform = DefaultPlatform::new()?;
-    let mut app = AlliumMenu::new(platform).await?;
+    let mut app = AlliumMenu::new(platform, Stylesheet::load()?).await?;
     app.prepare(info).await?;
     app.run_event_loop().await?;
     app.save()?;

--- a/crates/alliumd/src/alliumd.rs
+++ b/crates/alliumd/src/alliumd.rs
@@ -10,13 +10,15 @@ use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
 use common::battery::Battery;
 use common::constants::{
-    ALLIUM_GAME_INFO, ALLIUM_SD_ROOT, ALLIUM_VERSION, ALLIUMD_STATE, BATTERY_SHUTDOWN_THRESHOLD,
-    BATTERY_UPDATE_INTERVAL, BATTERY_WARNING_THRESHOLD, IDLE_TIMEOUT,
+    ALLIUM_GAME_INFO, ALLIUM_LAUNCHER, ALLIUM_SD_ROOT, ALLIUM_VERSION, ALLIUMD_STATE,
+    BATTERY_SHUTDOWN_THRESHOLD, BATTERY_UPDATE_INTERVAL, BATTERY_WARNING_THRESHOLD, IDLE_TIMEOUT,
+    MAX_BRIGHTNESS, MAX_VOLUME,
 };
 use common::display::settings::DisplaySettings;
 use common::locale::{Locale, LocaleSettings};
 use common::power::{PowerButtonAction, PowerSettings, VolumeOnStartup};
 use common::retroarch::RetroArchCommand;
+use common::stylesheet::Stylesheet;
 use common::wifi::WiFiSettings;
 use enum_map::EnumMap;
 use log::{debug, error, info, trace, warn};
@@ -26,6 +28,8 @@ use tokio::process::{Child, Command};
 use common::database::Database;
 use common::game_info::GameInfo;
 use common::platform::{DefaultPlatform, Key, KeyEvent, Platform};
+
+use crate::osd::{Osd, OsdKind};
 
 #[cfg(unix)]
 use {
@@ -49,7 +53,7 @@ struct MenuHandle {
 }
 
 impl MenuHandle {
-    fn new() -> Self {
+    fn new(styles: Stylesheet) -> Self {
         let (tx, rx) = mpsc::channel::<Option<RetroArchInfo>>();
         let (done_tx, done_rx) = tokio::sync::mpsc::unbounded_channel();
         let rt = tokio::runtime::Handle::current();
@@ -57,7 +61,7 @@ impl MenuHandle {
         let handle = std::thread::spawn(move || -> Result<()> {
             rt.block_on(async {
                 let platform = common::platform::DefaultPlatform::new()?;
-                let mut app = AlliumMenu::new(platform).await?;
+                let mut app = AlliumMenu::new(platform, styles).await?;
 
                 while let Ok(info) = rx.recv() {
                     if let Err(e) = app.prepare(info).await {
@@ -93,6 +97,7 @@ pub struct AlliumD<P: Platform> {
     state: AlliumDState,
     locale: Locale,
     power_settings: PowerSettings,
+    osd: Osd<P>,
 }
 
 impl AlliumDState {
@@ -140,6 +145,14 @@ impl AlliumDState {
         let json = serde_json::to_string(self).unwrap();
         File::create(ALLIUMD_STATE.as_path())?.write_all(json.as_bytes())?;
         Ok(())
+    }
+}
+
+/// Sleeps until `deadline`, or forever when there is none — the select! arm needs no precondition
+async fn sleep_until_wake(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
     }
 }
 
@@ -226,8 +239,11 @@ impl AlliumD<DefaultPlatform> {
         let main = spawn_main().await?;
         let locale = Locale::new(&LocaleSettings::load()?.lang);
 
+        // One load per process: font data is Arc'd, so clones share it
+        let styles = Stylesheet::load()?;
+
         // Spawn the persistent menu thread at startup
-        let menu = MenuHandle::new();
+        let menu = MenuHandle::new(styles.clone());
 
         platform.daemon();
 
@@ -242,6 +258,7 @@ impl AlliumD<DefaultPlatform> {
             state,
             locale,
             power_settings,
+            osd: Osd::new(styles),
         })
     }
 
@@ -315,6 +332,11 @@ impl AlliumD<DefaultPlatform> {
                     key_event = self.platform.poll() => {
                         self.handle_key_event(key_event).await?;
                     }
+                    _ = sleep_until_wake(self.osd.next_wake()) => {
+                        if let Err(e) = self.osd.tick() {
+                            error!("failed to update OSD: {}", e);
+                        }
+                    }
                     _ = self.menu.done_rx.recv() => {
                         info!("menu finished, resuming game");
                         self.menu_open = false;
@@ -350,6 +372,11 @@ impl AlliumD<DefaultPlatform> {
             tokio::select! {
                 key_event = self.platform.poll() => {
                     self.handle_key_event(key_event).await?;
+                }
+                _ = sleep_until_wake(self.osd.next_wake()) => {
+                    if let Err(e) = self.osd.tick() {
+                        error!("failed to update OSD: {}", e);
+                    }
                 }
             }
         }
@@ -478,6 +505,9 @@ impl AlliumD<DefaultPlatform> {
                             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                         }
 
+                        // The plate would keep re-flushing over the menu until its timeout
+                        self.hide_osd();
+
                         self.menu_open = true;
                         if self.menu.tx.send(info).is_err() {
                             error!("failed to send to menu thread");
@@ -496,6 +526,8 @@ impl AlliumD<DefaultPlatform> {
     #[cfg(unix)]
     async fn handle_charging(&mut self) -> Result<()> {
         info!("charging...");
+
+        self.hide_osd();
 
         signal(&self.main, Signal::SIGSTOP)?;
 
@@ -537,6 +569,7 @@ impl AlliumD<DefaultPlatform> {
     #[cfg(unix)]
     async fn handle_suspend(&mut self) -> Result<()> {
         info!("suspending...");
+        self.hide_osd();
         #[allow(clippy::let_unit_value)]
         let ctx = self.platform.suspend()?;
         signal(&self.main, Signal::SIGSTOP)?;
@@ -573,6 +606,7 @@ impl AlliumD<DefaultPlatform> {
 
         debug!("terminating, saving state");
 
+        self.hide_osd();
         self.state.time = Utc::now();
         self.state.save()?;
 
@@ -635,18 +669,61 @@ impl AlliumD<DefaultPlatform> {
         Path::new(&*ALLIUM_GAME_INFO).exists()
     }
 
+    /// Whether the foreground repaints the frame itself; apps exec over the launcher
+    /// without writing game info, so `is_ingame` alone misses them
+    fn foreground_repaints(&self) -> bool {
+        let exe = self
+            .main
+            .id()
+            .and_then(|pid| fs::canonicalize(format!("/proc/{pid}/exe")).ok());
+        let launcher = fs::canonicalize(ALLIUM_LAUNCHER.as_path()).ok();
+        match (exe, launcher) {
+            (Some(exe), Some(launcher)) => exe != launcher,
+            _ => self.is_ingame(),
+        }
+    }
+
     fn add_volume(&mut self, add: i32) -> Result<()> {
         info!("adding volume: {}", add);
-        self.state.volume = (self.state.volume + add).clamp(0, 20);
+        self.state.volume = (self.state.volume + add).clamp(0, MAX_VOLUME);
+        // Draw first: set_volume spawns myctl, which costs tens of ms on this SoC
+        self.show_osd(
+            OsdKind::Volume,
+            self.state.volume as f32 / MAX_VOLUME as f32,
+        );
         self.platform.set_volume(self.state.volume)?;
         Ok(())
     }
 
     fn add_brightness(&mut self, add: i8) -> Result<()> {
         info!("adding brightness: {}", add);
-        self.state.brightness = (self.state.brightness as i8 + add).clamp(0, 100) as u8;
+        self.state.brightness =
+            (self.state.brightness as i8 + add).clamp(0, MAX_BRIGHTNESS as i8) as u8;
+        // Draw first, matching add_volume, so the two paths behave the same
+        self.show_osd(
+            OsdKind::Brightness,
+            self.state.brightness as f32 / MAX_BRIGHTNESS as f32,
+        );
         self.platform.set_brightness(self.state.brightness)?;
         Ok(())
+    }
+
+    fn show_osd(&mut self, kind: OsdKind, fraction: f32) {
+        let repainting = self.foreground_repaints() && !self.menu_open;
+        // Cosmetic only: a failed overlay must not take down the daemon
+        if let Err(e) = self
+            .osd
+            .show(&mut self.platform, kind, fraction, repainting)
+        {
+            error!("failed to show OSD: {}", e);
+        }
+    }
+
+    fn hide_osd(&mut self) {
+        // Cosmetic only: must not block suspend or shutdown
+        if let Err(e) = self.osd.hide() {
+            error!("failed to hide OSD: {}", e);
+        }
     }
 }
 

--- a/crates/alliumd/src/main.rs
+++ b/crates/alliumd/src/main.rs
@@ -2,6 +2,7 @@
 #![warn(rust_2018_idioms)]
 
 mod alliumd;
+mod osd;
 
 use anyhow::Result;
 use simple_logger::SimpleLogger;

--- a/crates/alliumd/src/osd.rs
+++ b/crates/alliumd/src/osd.rs
@@ -87,10 +87,11 @@ struct Surface<P: Platform> {
 
 impl<P: Platform> Surface<P> {
     fn new(platform: &mut P, styles: &Stylesheet) -> Result<Self> {
-        // The constructor reads the current frame, so save() keeps the pre-OSD background
-        let mut display = platform.display()?;
-        display.save()?;
+        let mut display = platform.display_partial()?;
         let plate = Plate::new(&display, styles);
+        // Nothing outside the plate is ever drawn or restored, so read no more of the frame
+        display.read_rect(plate.rect)?;
+        display.save()?;
         Ok(Self { display, plate })
     }
 

--- a/crates/alliumd/src/osd.rs
+++ b/crates/alliumd/src/osd.rs
@@ -1,0 +1,253 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use common::constants::UI_FRAME_INTERVAL;
+use common::display::{Display, RectHold, draw_speaker_icon, draw_sun_icon, fill_rounded_rect};
+use common::geom::Rect;
+use common::platform::Platform;
+use common::stylesheet::Stylesheet;
+use tokio::time::Instant;
+
+/// How long the indicator stays on screen after the last change
+const HIDE_TIMEOUT: Duration = Duration::from_millis(1000);
+/// Twice per UI frame, since a launcher redraw flushes the whole screen
+const UI_REDRAW_PERIOD: Duration = Duration::from_micros(UI_FRAME_INTERVAL.as_micros() as u64 / 2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OsdKind {
+    Volume,
+    Brightness,
+}
+
+/// The plate and its contents, placed from the framebuffer size and the theme
+#[derive(Clone, Copy)]
+struct Plate {
+    rect: Rect,
+    icon: Rect,
+    bar: Rect,
+    /// Corner rounding, kept equal to the horizontal padding
+    radius: u32,
+}
+
+impl Plate {
+    fn new<D: Display>(display: &D, styles: &Stylesheet) -> Self {
+        let font_size = styles.ui.ui_font.size;
+        // Same theme-driven paddings as the launcher's toast popups
+        let padding_x = styles.ui.margin_x.max(0) as u32;
+        let padding_y = styles.ui.margin_y.max(0) as u32;
+        let icon_side = font_size * 2 / 3;
+
+        let bar_w = display.width() / 4;
+        let bar_h = font_size / 3;
+        let plate_w = padding_x + icon_side + padding_x + bar_w + padding_x;
+        let plate_h = font_size + padding_y * 2;
+
+        // Clear the button hint row, positioned by ButtonHints::ensure_layout
+        let hint_h = styles.button_size().max(styles.button_hint_font_size()) as u32;
+        let bottom_margin = padding_x + hint_h + padding_y;
+
+        let rect = Rect::new(
+            (display.width() as i32 - plate_w as i32) / 2,
+            display.height() as i32 - (plate_h + bottom_margin) as i32,
+            plate_w,
+            plate_h,
+        );
+        Self {
+            rect,
+            icon: Rect::new(
+                rect.x + padding_x as i32,
+                rect.y + ((plate_h - icon_side) / 2) as i32,
+                icon_side,
+                icon_side,
+            ),
+            bar: Rect::new(
+                rect.x + (padding_x + icon_side + padding_x) as i32,
+                rect.y + ((plate_h - bar_h) / 2) as i32,
+                bar_w,
+                bar_h,
+            ),
+            radius: padding_x,
+        }
+    }
+}
+
+/// How often the plate has to be rewritten to stay on screen
+enum Refresh {
+    /// Nothing repaints under us: re-flush periodically, restore the background on hide
+    Periodic { next_redraw: Instant },
+    /// The app rewrites the whole frame ~60/s, so a stamper thread owns the rect
+    Continuous(RectHold),
+}
+
+/// The framebuffer we draw on, and the plate placed on it
+struct Surface<P: Platform> {
+    display: P::Display,
+    plate: Plate,
+}
+
+impl<P: Platform> Surface<P> {
+    fn new(platform: &mut P, styles: &Stylesheet) -> Result<Self> {
+        // The constructor reads the current frame, so save() keeps the pre-OSD background
+        let mut display = platform.display()?;
+        display.save()?;
+        let plate = Plate::new(&display, styles);
+        Ok(Self { display, plate })
+    }
+
+    /// Hands the plate to a stamper thread, on platforms that have one
+    fn hold_plate(&mut self) -> Result<Option<RectHold>> {
+        self.display.hold_rect(self.plate.rect, self.plate.radius)
+    }
+
+    fn flush_plate(&mut self) -> Result<()> {
+        self.display.flush_rect(self.plate.rect)
+    }
+
+    /// Puts the pre-OSD background back where the plate was
+    fn restore_plate(&mut self) -> Result<()> {
+        self.display.load(self.plate.rect)?;
+        self.display.flush_rect(self.plate.rect)
+    }
+
+    fn draw(&mut self, styles: &Stylesheet, kind: OsdKind, fraction: f32) -> Result<()> {
+        let Plate {
+            rect,
+            icon,
+            bar,
+            radius,
+        } = self.plate;
+
+        // Repaint over the saved background so a shrinking bar leaves no residue
+        self.display.load(rect)?;
+
+        // Unlike ui.background_color, this one is opaque in every bundled theme
+        fill_rounded_rect(
+            &mut self.display.pixmap_mut(),
+            rect,
+            radius,
+            styles.menu.background_color,
+        );
+
+        match kind {
+            OsdKind::Volume => {
+                draw_speaker_icon(&mut self.display.pixmap_mut(), icon, styles.ui.text_color)
+            }
+            OsdKind::Brightness => {
+                draw_sun_icon(&mut self.display.pixmap_mut(), icon, styles.ui.text_color)
+            }
+        }
+
+        let bar_radius = bar.h / 2;
+        fill_rounded_rect(
+            &mut self.display.pixmap_mut(),
+            bar,
+            bar_radius,
+            styles.ui.disabled_color,
+        );
+        let fill_w = (bar.w as f32 * fraction.clamp(0.0, 1.0)).round() as u32;
+        if fill_w > 0 {
+            let fill = Rect::new(bar.x, bar.y, fill_w, bar.h);
+            fill_rounded_rect(
+                &mut self.display.pixmap_mut(),
+                fill,
+                bar_radius.min(fill_w / 2),
+                styles.ui.highlight_color,
+            );
+        }
+
+        self.display.flush_rect(rect)
+    }
+}
+
+/// State that exists only while the indicator is on screen
+struct Shown<P: Platform> {
+    surface: Surface<P>,
+    hide_at: Instant,
+    refresh: Refresh,
+}
+
+/// On-screen indicator drawn over whatever app owns the framebuffer.
+pub struct Osd<P: Platform> {
+    styles: Stylesheet,
+    shown: Option<Shown<P>>,
+}
+
+impl<P: Platform> Osd<P> {
+    pub fn new(styles: Stylesheet) -> Self {
+        Self {
+            styles,
+            shown: None,
+        }
+    }
+
+    /// When `tick()` is next due, or `None` while hidden — nothing to wake for.
+    pub fn next_wake(&self) -> Option<Instant> {
+        self.shown.as_ref().map(|shown| match shown.refresh {
+            Refresh::Periodic { next_redraw } => shown.hide_at.min(next_redraw),
+            Refresh::Continuous(_) => shown.hide_at,
+        })
+    }
+
+    pub fn show(
+        &mut self,
+        platform: &mut P,
+        kind: OsdKind,
+        fraction: f32,
+        repainting: bool,
+    ) -> Result<()> {
+        // Consuming the old state stops its stamper before the new content is drawn
+        let mut surface = match self.shown.take() {
+            Some(shown) => shown.surface,
+            None => Surface::new(platform, &self.styles)?,
+        };
+
+        surface.draw(&self.styles, kind, fraction)?;
+
+        let now = Instant::now();
+        let periodic = Refresh::Periodic {
+            next_redraw: now + UI_REDRAW_PERIOD,
+        };
+        self.shown = Some(Shown {
+            // Must precede the `surface` move: hold_plate takes it by &mut
+            refresh: if repainting {
+                match surface.hold_plate()? {
+                    Some(hold) => Refresh::Continuous(hold),
+                    // Nothing stamps here, so fall back to the static-UI cadence
+                    None => periodic,
+                }
+            } else {
+                periodic
+            },
+            surface,
+            hide_at: now + HIDE_TIMEOUT,
+        });
+        Ok(())
+    }
+
+    pub fn tick(&mut self) -> Result<()> {
+        let Some(shown) = self.shown.as_mut() else {
+            return Ok(());
+        };
+        let now = Instant::now();
+        if now >= shown.hide_at {
+            return self.hide();
+        }
+        if let Refresh::Periodic { next_redraw } = &mut shown.refresh {
+            *next_redraw = now + UI_REDRAW_PERIOD;
+            shown.surface.flush_plate()?;
+        }
+        Ok(())
+    }
+
+    pub fn hide(&mut self) -> Result<()> {
+        let Some(mut shown) = self.shown.take() else {
+            return Ok(());
+        };
+        match shown.refresh {
+            // The app repaints the frame itself; only static UI needs the background back
+            Refresh::Periodic { .. } => shown.surface.restore_plate()?,
+            Refresh::Continuous(hold) => drop(hold),
+        }
+        Ok(())
+    }
+}

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -84,6 +84,11 @@ lazy_static! {
 pub const IMAGE_WIDTH: u32 = 250;
 pub const SAVE_STATE_IMAGE_WIDTH: u32 = 333;
 
+/// Volume scale is 0..=MAX_VOLUME, mapped to the hardware dB curve at the platform layer.
+pub const MAX_VOLUME: i32 = 20;
+/// Brightness scale is 0..=MAX_BRIGHTNESS percent.
+pub const MAX_BRIGHTNESS: u8 = 100;
+
 /// After the battery level drops below this threshold, the charging LED will blink at 0.5Hz.
 pub const BATTERY_WARNING_THRESHOLD: i32 = 15;
 /// After the battery level drops below this threshold, the device will shut down.
@@ -97,6 +102,9 @@ pub const WIFI_UPDATE_INTERVAL: Duration = Duration::from_secs(10);
 
 /// The interval at which the clock is updated.
 pub const CLOCK_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
+
+/// The UI frame period; a launcher redraw flushes the whole screen.
+pub const UI_FRAME_INTERVAL: Duration = Duration::from_micros(166_667);
 
 /// How long to wait until the device is considered idle.
 pub const IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);

--- a/crates/common/src/display/mod.rs
+++ b/crates/common/src/display/mod.rs
@@ -82,6 +82,11 @@ pub trait Display: Sized {
         self.flush()
     }
 
+    /// Read `area` of the visible frame into the pixmap; a no-op where it already holds it
+    fn read_rect(&mut self, _area: Rect) -> Result<()> {
+        Ok(())
+    }
+
     /// Keep `area`, already drawn by the caller, restamped over an app that repaints the
     /// screen, until the returned hold is dropped. `None` when the platform cannot stamp
     fn hold_rect(&mut self, _area: Rect, _corner_radius: u32) -> Result<Option<RectHold>> {

--- a/crates/common/src/display/mod.rs
+++ b/crates/common/src/display/mod.rs
@@ -3,6 +3,9 @@ pub mod font;
 pub mod image;
 pub mod settings;
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use anyhow::Result;
 use tiny_skia::{
     BlendMode, FillRule, Paint, Path, PathBuilder, PixmapMut, PixmapRef, Stroke, Transform,
@@ -10,6 +13,29 @@ use tiny_skia::{
 
 use crate::display::color::Color;
 use crate::geom::{Point, Rect, Size};
+
+/// A thread stamping a region over a repainting foreground app; it runs until this is dropped
+pub struct RectHold {
+    stop: Arc<AtomicBool>,
+}
+
+impl RectHold {
+    /// Runs `stamp` on a thread until the returned hold is dropped; it polls the flag it is handed
+    pub fn spawn(stamp: impl FnOnce(&AtomicBool) + Send + 'static) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        std::thread::spawn({
+            let stop = Arc::clone(&stop);
+            move || stamp(&stop)
+        });
+        Self { stop }
+    }
+}
+
+impl Drop for RectHold {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+    }
+}
 
 pub trait Display: Sized {
     /// Get the width of the display in pixels
@@ -49,6 +75,17 @@ pub trait Display: Sized {
     /// Flush any pending changes to the display
     fn flush(&mut self) -> Result<()> {
         Ok(())
+    }
+
+    /// Flush a region of the display; defaults to a full flush
+    fn flush_rect(&mut self, _area: Rect) -> Result<()> {
+        self.flush()
+    }
+
+    /// Keep `area`, already drawn by the caller, restamped over an app that repaints the
+    /// screen, until the returned hold is dropped. `None` when the platform cannot stamp
+    fn hold_rect(&mut self, _area: Rect, _corner_radius: u32) -> Result<Option<RectHold>> {
+        Ok(None)
     }
 
     /// Sync with the display hardware
@@ -150,6 +187,100 @@ pub fn stroke_rect(pixmap: &mut PixmapMut<'_>, rect: Rect, stroke_width: f32, co
     {
         let path = PathBuilder::from_rect(ts_rect);
         pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
+    }
+}
+
+/// Draw a speaker-with-waves volume icon inside `rect`
+pub fn draw_speaker_icon(pixmap: &mut PixmapMut<'_>, rect: Rect, color: Color) {
+    let s = rect.w.min(rect.h) as f32;
+    let (x, y) = (rect.x as f32, rect.y as f32);
+    let paint = icon_paint(color);
+
+    // Speaker body and cone as one polygon
+    let mut pb = PathBuilder::new();
+    pb.move_to(x + 0.08 * s, y + 0.36 * s);
+    pb.line_to(x + 0.26 * s, y + 0.36 * s);
+    pb.line_to(x + 0.48 * s, y + 0.16 * s);
+    pb.line_to(x + 0.48 * s, y + 0.84 * s);
+    pb.line_to(x + 0.26 * s, y + 0.64 * s);
+    pb.line_to(x + 0.08 * s, y + 0.64 * s);
+    pb.close();
+    if let Some(path) = pb.finish() {
+        pixmap.fill_path(
+            &path,
+            &paint,
+            FillRule::Winding,
+            Transform::identity(),
+            None,
+        );
+    }
+
+    // Two sound waves to the right of the cone
+    let stroke = icon_stroke(s);
+    let (cx, cy) = (x + 0.52 * s, y + 0.5 * s);
+    let sweep = std::f32::consts::PI * 0.6;
+    const SEGMENTS: u32 = 12;
+    for radius in [0.22 * s, 0.36 * s] {
+        let mut pb = PathBuilder::new();
+        for i in 0..=SEGMENTS {
+            let angle = -sweep / 2.0 + sweep * i as f32 / SEGMENTS as f32;
+            let px = cx + radius * angle.cos();
+            let py = cy + radius * angle.sin();
+            if i == 0 {
+                pb.move_to(px, py);
+            } else {
+                pb.line_to(px, py);
+            }
+        }
+        if let Some(path) = pb.finish() {
+            pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
+        }
+    }
+}
+
+/// Draw a sun brightness icon inside `rect`
+pub fn draw_sun_icon(pixmap: &mut PixmapMut<'_>, rect: Rect, color: Color) {
+    let s = rect.w.min(rect.h) as f32;
+    let (cx, cy) = (rect.x as f32 + 0.5 * s, rect.y as f32 + 0.5 * s);
+    let paint = icon_paint(color);
+
+    if let Some(path) = PathBuilder::from_circle(cx, cy, 0.18 * s) {
+        pixmap.fill_path(
+            &path,
+            &paint,
+            FillRule::Winding,
+            Transform::identity(),
+            None,
+        );
+    }
+
+    // Eight rays around the core
+    let stroke = icon_stroke(s);
+    let mut pb = PathBuilder::new();
+    for i in 0..8 {
+        let (sin, cos) = (std::f32::consts::FRAC_PI_4 * i as f32).sin_cos();
+        pb.move_to(cx + 0.30 * s * cos, cy + 0.30 * s * sin);
+        pb.line_to(cx + 0.44 * s * cos, cy + 0.44 * s * sin);
+    }
+    if let Some(path) = pb.finish() {
+        pixmap.stroke_path(&path, &paint, &stroke, Transform::identity(), None);
+    }
+}
+
+fn icon_paint(color: Color) -> Paint<'static> {
+    Paint {
+        shader: tiny_skia::Shader::SolidColor(color.into()),
+        blend_mode: BlendMode::SourceOver,
+        anti_alias: true,
+        ..Default::default()
+    }
+}
+
+fn icon_stroke(icon_side: f32) -> Stroke {
+    Stroke {
+        width: (icon_side / 12.0).max(1.0),
+        line_cap: tiny_skia::LineCap::Round,
+        ..Default::default()
     }
 }
 

--- a/crates/common/src/platform/miyoo/evdev.rs
+++ b/crates/common/src/platform/miyoo/evdev.rs
@@ -65,16 +65,20 @@ impl EvdevKeys {
             };
             let event = result.unwrap();
             if event.event_type() == EventType::KEY {
-                let key = event.code();
-                let key: Key = key.into();
-                if event.timestamp().elapsed().unwrap() > MAXIMUM_FRAME_TIME {
+                let key: Key = event.code().into();
+                let value = event.value();
+                // Skip stale presses after a stall, but a stale release must still
+                // pass through or the key stays latched in the caller's key state
+                if value != 0
+                    && event.timestamp().elapsed().unwrap_or_default() > MAXIMUM_FRAME_TIME
+                {
                     continue;
                 }
-                return match event.value() {
+                return match value {
                     0 => KeyEvent::Released(key),
                     1 => KeyEvent::Pressed(key),
                     2 => KeyEvent::Autorepeat(key),
-                    _ => unreachable!(),
+                    _ => unreachable!("evdev KEY events carry value 0, 1 or 2"),
                 };
             }
         }

--- a/crates/common/src/platform/miyoo/framebuffer.rs
+++ b/crates/common/src/platform/miyoo/framebuffer.rs
@@ -22,6 +22,14 @@ pub struct FramebufferDisplay {
 
 impl FramebufferDisplay {
     pub fn new() -> Result<FramebufferDisplay> {
+        let mut display = Self::blank()?;
+        let frame = display.bounding_box();
+        display.read_frame_rect(frame);
+        Ok(display)
+    }
+
+    /// A display whose pixmap starts empty; the caller reads what it needs with `read_rect`
+    pub fn blank() -> Result<FramebufferDisplay> {
         let iface = Framebuffer::new("/dev/fb0")?;
         trace!(
             "init fb: var_screen_info: {:?}, fix_screen_info: {:?}",
@@ -30,43 +38,47 @@ impl FramebufferDisplay {
 
         let width = iface.var_screen_info.xres;
         let height = iface.var_screen_info.yres;
-
-        let mut pixmap = Pixmap::new(width, height)
+        let pixmap = Pixmap::new(width, height)
             .ok_or_else(|| anyhow!("Failed to create pixmap {}x{}", width, height))?;
-
-        // Read initial framebuffer content
-        let background = iface.read_frame();
-        let (xoffset, yoffset) = (
-            iface.var_screen_info.xoffset as usize,
-            iface.var_screen_info.yoffset as usize,
-        );
-        let bytes_per_pixel = iface.var_screen_info.bits_per_pixel / 8;
-        let location = (yoffset * width as usize + xoffset) * bytes_per_pixel as usize;
-
-        // Copy initial background (need to convert from BGRA and unrotate)
-        for y in 0..height {
-            for x in 0..width {
-                // Framebuffer is rotated 180°, so read from reversed position
-                let fb_x = width - x - 1;
-                let fb_y = height - y - 1;
-                let fb_idx = location + ((fb_y * width + fb_x) as usize * bytes_per_pixel as usize);
-
-                let b = background[fb_idx];
-                let g = background[fb_idx + 1];
-                let r = background[fb_idx + 2];
-                let a = background[fb_idx + 3];
-
-                let color = Color::rgba(r, g, b, a);
-                let idx = (y * width + x) as usize;
-                pixmap.pixels_mut()[idx] = color.into();
-            }
-        }
 
         Ok(FramebufferDisplay {
             pixmap,
             iface,
             saved: Vec::new(),
         })
+    }
+
+    /// Copies `rect` of the visible frame into the pixmap, unrotating it and BGRA to RGBA
+    fn read_frame_rect(&mut self, rect: Rect) {
+        let width = self.pixmap.width() as usize;
+        let height = self.pixmap.height() as usize;
+        let bytes_per_pixel = (self.iface.var_screen_info.bits_per_pixel / 8) as usize;
+        let xoffset = self.iface.var_screen_info.xoffset as usize;
+        let yoffset = self.iface.var_screen_info.yoffset as usize;
+        let location = (yoffset * width + xoffset) * bytes_per_pixel;
+
+        let x0 = rect.x.max(0) as usize;
+        let y0 = rect.y.max(0) as usize;
+        let x1 = (rect.right().max(0) as usize).min(width);
+        let y1 = (rect.bottom().max(0) as usize).min(height);
+
+        let frame = self.iface.read_frame();
+        let pixels = self.pixmap.pixels_mut();
+        for y in y0..y1 {
+            // The framebuffer is rotated 180 degrees, so both axes run backwards
+            let fb_y = height - 1 - y;
+            for x in x0..x1 {
+                let fb_x = width - 1 - x;
+                let fb_idx = location + (fb_y * width + fb_x) * bytes_per_pixel;
+                let color = Color::rgba(
+                    frame[fb_idx + 2],
+                    frame[fb_idx + 1],
+                    frame[fb_idx],
+                    frame[fb_idx + 3],
+                );
+                pixels[y * width + x] = color.into();
+            }
+        }
     }
 
     /// Packs `area` into fb-ordered rows, so the stamping thread only does memcpy
@@ -236,25 +248,8 @@ impl Display for FramebufferDisplay {
         let bytes_per_pixel = (self.iface.var_screen_info.bits_per_pixel / 8) as usize;
         let location = (yoffset * width + xoffset) * bytes_per_pixel;
 
-        let background = self.iface.read_frame();
-
-        // Re-read framebuffer content (convert from BGRA and unrotate)
-        for y in 0..height {
-            for x in 0..width {
-                let fb_x = width - x - 1;
-                let fb_y = height - y - 1;
-                let fb_idx = location + (fb_y * width + fb_x) * bytes_per_pixel;
-
-                let b = background[fb_idx];
-                let g = background[fb_idx + 1];
-                let r = background[fb_idx + 2];
-                let a = background[fb_idx + 3];
-
-                let color = Color::rgba(r, g, b, a);
-                let idx = y * width + x;
-                self.pixmap.pixels_mut()[idx] = color.into();
-            }
-        }
+        let frame = self.bounding_box();
+        self.read_frame_rect(frame);
 
         if yoffset != 0 {
             let frame_size = width * height * bytes_per_pixel;
@@ -290,6 +285,14 @@ impl Display for FramebufferDisplay {
         self.iface.var_screen_info = Framebuffer::get_var_screeninfo(&self.iface.device)
             .map_err(|e| anyhow!("failed to get var_screen_info: {}", e))?;
         self.write_rect(area);
+        Ok(())
+    }
+
+    fn read_rect(&mut self, area: Rect) -> Result<()> {
+        // Re-read offsets: the foreground app may have moved yoffset since creation
+        self.iface.var_screen_info = Framebuffer::get_var_screeninfo(&self.iface.device)
+            .map_err(|e| anyhow!("failed to get var_screen_info: {}", e))?;
+        self.read_frame_rect(area);
         Ok(())
     }
 

--- a/crates/common/src/platform/miyoo/framebuffer.rs
+++ b/crates/common/src/platform/miyoo/framebuffer.rs
@@ -1,11 +1,18 @@
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
 use anyhow::{Result, anyhow, bail};
 use framebuffer::Framebuffer;
-use log::{trace, warn};
+use log::{debug, trace, warn};
 use tiny_skia::{Pixmap, PixmapMut, PixmapRef};
 
-use crate::display::Display;
 use crate::display::color::Color;
+use crate::display::{Display, RectHold};
 use crate::geom::Rect;
+
+/// Pause between stamping passes, matching Onion; probing or yielding instead costs whole
+/// frames on this dual-core SoC
+const STAMP_PAUSE: Duration = Duration::from_micros(100);
 
 pub struct FramebufferDisplay {
     pixmap: Pixmap,
@@ -60,6 +67,144 @@ impl FramebufferDisplay {
             iface,
             saved: Vec::new(),
         })
+    }
+
+    /// Packs `area` into fb-ordered rows, so the stamping thread only does memcpy
+    fn stamp(&self, area: Rect, corner_radius: u32) -> Option<Stamp> {
+        let width = self.width() as usize;
+        let height = self.height() as usize;
+        let bytes_per_pixel = (self.iface.var_screen_info.bits_per_pixel / 8) as usize;
+
+        let x0 = area.x.max(0) as usize;
+        let y0 = area.y.max(0) as usize;
+        let x1 = (area.right().max(0) as usize).min(width);
+        let y1 = (area.bottom().max(0) as usize).min(height);
+        if x0 >= x1 || y0 >= y1 {
+            return None;
+        }
+
+        // Trim to the rounding so the corners keep the app's pixels, not a frozen frame
+        let radius = (corner_radius as usize)
+            .min((x1 - x0) / 2)
+            .min((y1 - y0) / 2) as f32;
+        let row_h = (y1 - y0) as f32;
+        let mut rows = Vec::with_capacity(y1 - y0);
+        let mut bytes = Vec::with_capacity((y1 - y0) * (x1 - x0) * bytes_per_pixel);
+        for y in y0..y1 {
+            let dy = (y - y0) as f32 + 0.5;
+            let dist = (radius - dy).max(dy - (row_h - radius)).max(0.0);
+            let inset = (radius - (radius * radius - dist * dist).sqrt()).ceil() as usize;
+            let (rx0, rx1) = (x0 + inset, x1 - inset);
+            if rx0 >= rx1 {
+                continue;
+            }
+            let start = bytes.len();
+            // Reversed x, and fb_y below, are the two halves of the 180 degree rotation
+            for x in (rx0..rx1).rev() {
+                let pixel = self.pixmap.pixels()[y * width + x];
+                bytes.extend_from_slice(&[pixel.blue(), pixel.green(), pixel.red(), pixel.alpha()]);
+            }
+            let fb_y = height - 1 - y;
+            let fb_x0 = width - rx1;
+            rows.push(StampRow {
+                offset: (fb_y * width + fb_x0) * bytes_per_pixel,
+                start,
+                len: bytes.len() - start,
+            });
+        }
+        if rows.is_empty() {
+            return None;
+        }
+
+        let pages = (self.iface.var_screen_info.yres_virtual as usize / height.max(1)).clamp(1, 3);
+        debug!(
+            "holding {}x{} rect over fb {}x{} (virtual {}, stride {}, {} bpp, {} pages)",
+            x1 - x0,
+            y1 - y0,
+            width,
+            height,
+            self.iface.var_screen_info.yres_virtual,
+            self.iface.fix_screen_info.line_length,
+            bytes_per_pixel * 8,
+            pages,
+        );
+        Some(Stamp {
+            bytes: bytes.into_boxed_slice(),
+            rows: rows.into_boxed_slice(),
+            pages,
+            page_stride: width * height * bytes_per_pixel,
+        })
+    }
+
+    fn write_rect(&mut self, rect: Rect) {
+        let yoffset = self.iface.var_screen_info.yoffset as usize;
+        self.write_rect_at(rect, yoffset);
+    }
+
+    fn write_rect_at(&mut self, rect: Rect, yoffset: usize) {
+        let xoffset = self.iface.var_screen_info.xoffset as usize;
+        let width = self.width() as usize;
+        let height = self.height() as usize;
+        let bytes_per_pixel = (self.iface.var_screen_info.bits_per_pixel / 8) as usize;
+        let location = (yoffset * width + xoffset) * bytes_per_pixel;
+
+        if location + height * width * bytes_per_pixel > self.iface.frame.len() {
+            return;
+        }
+
+        let x0 = rect.x.max(0) as usize;
+        let y0 = rect.y.max(0) as usize;
+        let x1 = (rect.right().max(0) as usize).min(width);
+        let y1 = (rect.bottom().max(0) as usize).min(height);
+
+        // Write pixmap to framebuffer with 180° rotation and BGRA format
+        for y in y0..y1 {
+            for x in x0..x1 {
+                let idx = y * width + x;
+                let pixel = self.pixmap.pixels()[idx];
+
+                // Apply 180° rotation when writing to framebuffer
+                let fb_x = width - x - 1;
+                let fb_y = height - y - 1;
+                let fb_idx = location + (fb_y * width + fb_x) * bytes_per_pixel;
+
+                // Write as BGRA (use premultiplied values directly)
+                self.iface.frame[fb_idx] = pixel.blue();
+                self.iface.frame[fb_idx + 1] = pixel.green();
+                self.iface.frame[fb_idx + 2] = pixel.red();
+                self.iface.frame[fb_idx + 3] = pixel.alpha();
+            }
+        }
+    }
+}
+
+/// One row of the stamp: where it goes within a page, and its slice of `Stamp::bytes`
+struct StampRow {
+    offset: usize,
+    start: usize,
+    len: usize,
+}
+
+/// Rows of a rect in fb byte order, to be repeated across every page the app may flip to
+struct Stamp {
+    /// Every row back to back, so a pass reads the source linearly
+    bytes: Box<[u8]>,
+    rows: Box<[StampRow]>,
+    pages: usize,
+    page_stride: usize,
+}
+
+impl Stamp {
+    fn blit(&self, frame: &mut [u8]) {
+        for page in 0..self.pages {
+            let base = page * self.page_stride;
+            for row in &self.rows {
+                let at = base + row.offset;
+                if let Some(dst) = frame.get_mut(at..at + row.len) {
+                    dst.copy_from_slice(&self.bytes[row.start..row.start + row.len]);
+                }
+            }
+        }
     }
 }
 
@@ -136,35 +281,33 @@ impl Display for FramebufferDisplay {
     }
 
     fn flush(&mut self) -> Result<()> {
-        let (xoffset, yoffset) = (
-            self.iface.var_screen_info.xoffset as usize,
-            self.iface.var_screen_info.yoffset as usize,
-        );
-        let width = self.width() as usize;
-        let height = self.height() as usize;
-        let bytes_per_pixel = (self.iface.var_screen_info.bits_per_pixel / 8) as usize;
-        let location = (yoffset * width + xoffset) * bytes_per_pixel;
-
-        // Write pixmap to framebuffer with 180° rotation and BGRA format
-        for y in 0..height {
-            for x in 0..width {
-                let idx = y * width + x;
-                let pixel = self.pixmap.pixels()[idx];
-
-                // Apply 180° rotation when writing to framebuffer
-                let fb_x = width - x - 1;
-                let fb_y = height - y - 1;
-                let fb_idx = location + (fb_y * width + fb_x) * bytes_per_pixel;
-
-                // Write as BGRA (use premultiplied values directly)
-                self.iface.frame[fb_idx] = pixel.blue();
-                self.iface.frame[fb_idx + 1] = pixel.green();
-                self.iface.frame[fb_idx + 2] = pixel.red();
-                self.iface.frame[fb_idx + 3] = pixel.alpha();
-            }
-        }
-
+        self.write_rect(self.bounding_box());
         Ok(())
+    }
+
+    fn flush_rect(&mut self, area: Rect) -> Result<()> {
+        // Re-read offsets: the foreground app may have moved yoffset since creation
+        self.iface.var_screen_info = Framebuffer::get_var_screeninfo(&self.iface.device)
+            .map_err(|e| anyhow!("failed to get var_screen_info: {}", e))?;
+        self.write_rect(area);
+        Ok(())
+    }
+
+    fn hold_rect(&mut self, area: Rect, corner_radius: u32) -> Result<Option<RectHold>> {
+        self.flush_rect(area)?;
+        let Some(stamp) = self.stamp(area, corner_radius) else {
+            return Ok(None);
+        };
+
+        Ok(Some(RectHold::spawn(move |stop| {
+            let Ok(mut iface) = Framebuffer::new("/dev/fb0") else {
+                return;
+            };
+            while !stop.load(Ordering::Relaxed) {
+                stamp.blit(&mut iface.frame);
+                std::thread::sleep(STAMP_PAUSE);
+            }
+        })))
     }
 
     fn save(&mut self) -> Result<()> {

--- a/crates/common/src/platform/miyoo/mod.rs
+++ b/crates/common/src/platform/miyoo/mod.rs
@@ -73,6 +73,10 @@ impl Platform for MiyooPlatform {
         FramebufferDisplay::new()
     }
 
+    fn display_partial(&mut self) -> Result<FramebufferDisplay> {
+        FramebufferDisplay::blank()
+    }
+
     fn battery(&self) -> Result<Box<dyn Battery>> {
         Ok(match self.model {
             MiyooDeviceModel::Miyoo283 => Box::new(Miyoo283Battery::new()),

--- a/crates/common/src/platform/miyoo/volume.rs
+++ b/crates/common/src/platform/miyoo/volume.rs
@@ -4,8 +4,9 @@ use std::fs::File;
 use std::io::Write;
 use std::process::Command;
 
+use crate::constants::MAX_VOLUME;
+
 const MIN_VOLUME: i32 = 0;
-const MAX_VOLUME: i32 = 20;
 
 /// Set volume output between -60 and 30
 fn set_volume_raw(volume: i32) -> Result<()> {
@@ -22,7 +23,8 @@ fn set_volume_raw(volume: i32) -> Result<()> {
 // | -60 | -46 | -38 | -33 | -28 | -25 | -22 | -19 | -17 | -15 | -13 | -11 |  -9 |  -8 |  -7 |  -5 |  -4 |  -3 |  -2 |  -1 |   0 |
 pub fn set_volume(volume: i32) -> Result<()> {
     let volume = volume.clamp(MIN_VOLUME, MAX_VOLUME);
-    let volume_raw = (volume as f32 + 1.0).log10() / 21f32.log10() * 60.0 - 60.0;
+    let volume_raw =
+        (volume as f32 + 1.0).log10() / (MAX_VOLUME as f32 + 1.0).log10() * 60.0 - 60.0;
     debug!("set volume: {}", volume_raw as i32);
     set_volume_raw(volume_raw as i32)?;
     save_volume_raw(volume_raw as i32)?;

--- a/crates/common/src/platform/mod.rs
+++ b/crates/common/src/platform/mod.rs
@@ -38,6 +38,12 @@ pub trait Platform {
 
     fn display(&mut self) -> Result<Self::Display>;
 
+    /// A display whose pixmap may start empty, for callers that fill only the part of the
+    /// frame they need with `Display::read_rect`
+    fn display_partial(&mut self) -> Result<Self::Display> {
+        self.display()
+    }
+
     fn battery(&self) -> Result<Self::Battery>;
 
     async fn poll(&mut self) -> KeyEvent;

--- a/crates/common/src/view/clock.rs
+++ b/crates/common/src/view/clock.rs
@@ -8,7 +8,6 @@ use chrono::Local;
 use tokio::sync::mpsc::Sender;
 
 use crate::constants::CLOCK_UPDATE_INTERVAL;
-use crate::display::Display;
 use crate::geom::{Alignment, Point, Rect};
 use crate::platform::{DefaultPlatform, KeyEvent, Platform};
 use crate::resources::Resources;

--- a/crates/common/src/view/image.rs
+++ b/crates/common/src/view/image.rs
@@ -54,8 +54,10 @@ impl Image {
     }
 
     pub fn set_border_radius(&mut self, radius: u32) -> &mut Self {
-        self.border_radius = radius;
-        self.dirty = true;
+        if radius != self.border_radius {
+            self.border_radius = radius;
+            self.dirty = true;
+        }
         self
     }
 
@@ -171,14 +173,10 @@ impl View for Image {
         display: &mut <DefaultPlatform as Platform>::Display,
         _styles: &Stylesheet,
     ) -> Result<bool> {
-        let image_loaded = if let Some(ref path) = self.path {
-            let image_opt = self
-                .image
+        if let Some(ref path) = self.path {
+            self.image
                 .get_or_init(|| self.image(path, self.rect, self.mode, self.border_radius));
-            image_opt.is_some()
-        } else {
-            false
-        };
+        }
 
         display.load(self.rect)?;
         if let Some(Some(image)) = self.image.get() {
@@ -190,7 +188,8 @@ impl View for Image {
             );
         }
 
-        self.dirty = !image_loaded && self.path.is_some();
+        // A failed load is cached, so asking to be drawn again can only spin
+        self.dirty = false;
         Ok(true)
     }
 

--- a/crates/common/src/view/label.rs
+++ b/crates/common/src/view/label.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 use std::time::Duration;
 
 use crate::command::Command;
+use crate::constants::UI_FRAME_INTERVAL;
 use crate::geom::{Alignment, Point, Rect};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -39,7 +40,7 @@ where
 }
 
 const SCROLL_DELAY: Duration = Duration::from_millis(1000);
-const SCROLL_INTERVAL: Duration = Duration::from_micros(166_667);
+const SCROLL_INTERVAL: Duration = UI_FRAME_INTERVAL;
 
 impl<S> Label<S>
 where

--- a/crates/common/src/view/status_bar.rs
+++ b/crates/common/src/view/status_bar.rs
@@ -85,8 +85,8 @@ where
         if self.should_draw() && styles.status_bar.status_backdrop_color.a() > 0 {
             let mut bbox = self.row.bounding_box(styles);
             if bbox.w > 0 && bbox.h > 0 {
-                let padding_x = styles.ui.padding_x as i32;
-                let padding_y = styles.ui.padding_y as i32;
+                let padding_x = styles.ui.padding_x;
+                let padding_y = styles.ui.padding_y;
                 bbox.x -= padding_x;
                 bbox.y -= padding_y;
                 bbox.w += (padding_x * 2) as u32;


### PR DESCRIPTION
Adds volume and brightness indicators at the bottom of the screen with an icon and a bar showing for one second. It works in the launcher, in apps, in games and over the in game menu.

<img width="376" height="280" alt="2025-08-25_20-10-14-Allium" src="https://github.com/user-attachments/assets/ad3b4634-92ea-4a64-8756-4bb4c4e726b7" />

### How it works

`alliumd` owns the indicator, because it sees keys in every context drawing from the launcher would leave in-game changes invisible. So `Osd` renders into the framebuffer over whatever is in the foreground.

Keeping the plate visible needs two different strategies:

- **Over something that repaints itself** (a game or an app) a background thread restamps the plate rect every 100 µs until it is dismissed. This is the same Onion uses. Two cheaper designs were tried on device first and both flickered visibly.
- **Over static UI** (launcher, menu) nothing else writes the framebuffer, so the plate is simply redrawn twice per UI frame and the background restored on dismiss. A stamper here would be three orders of magnitude more memory traffic for no gain.

Which one applies is decided by reading `/proc/<pid>/exe` for the foreground process, not by`is_ingame()` - the launcher `exec`s apps over itself, so the PID never changes and no game info is written, and apps would get the wrong cadence.

### Geometry and colours come from the theme

No hardcoded pixels. `ui.margin_x` gives the horizontal paddings and the corner radius, `ui.margin_y` the vertical ones, `ui_font.size` the plate height with the icon at 2/3 and the bar at 1/3. Fill is menu.background_color`, which is opaque in every theme.

### Other fixes in this branch

Found while building this, each its own commit:

- **evdev**: stale `Released` events were dropped, so a slow frame could latch a key in `AlliumD::keys` forever - after which the ingame menu would not open.
- **`Image` no longer asks to be redrawn after a failed load.** The result is cached in a `OnceLock`, so the retry could never succeed, while the widget kept the whole launcher flushing at 6 fps for as long as such an entry was selected.
- **App icons resolve** (`entry/app.rs`): `config.icon` is stated relative to the pak just like  `config.launch`, but only `launch` was joined to the pak directory, so icons never loaded. **This changes how the Apps tab looks** - icons appear where there were none.
- **`allium-menu`'s `debug-ui` feature builds** - it never forwarded to `common/debug-ui`.
- Two pre-existing clippy lints, and one redundant `Stylesheet::load()` in the theme settings view.

### Testing

Device-tested on a Miyoo Mini Flip: no flicker in a game, in an app (PICO-8), or on the launcher's Apps tab; the plate appears instantly; Checked against two themes.