### PR TITLE
perf: skip the font load in show

### DIFF
--- a/crates/common/src/stylesheet.rs
+++ b/crates/common/src/stylesheet.rs
@@ -399,6 +399,13 @@ impl Stylesheet {
     }
 
     pub fn load_from_theme(theme: &Theme) -> Result<Self> {
+        let mut styles = Self::parse_theme(theme)?;
+        styles.load_fonts()?;
+        Ok(styles)
+    }
+
+    /// Reads the theme's stylesheet and its override file, omitting fonts
+    fn parse_theme(theme: &Theme) -> Result<Self> {
         let stylesheet_path = ALLIUM_THEMES_DIR.join(&theme.0).join("stylesheet.json");
         if !stylesheet_path.exists() {
             return Err(anyhow::anyhow!(
@@ -436,7 +443,6 @@ impl Stylesheet {
             }
         }
 
-        styles.load_fonts()?;
         Ok(styles)
     }
 
@@ -451,6 +457,17 @@ impl Stylesheet {
         self.recents = other.recents;
         self.games = other.games;
         self.menu = other.menu;
+    }
+
+    /// Separate from `load` because reading the fonts costs most of the time.
+    pub fn load_background_color() -> Color {
+        Self::parse_theme(&Theme::load())
+            .unwrap_or_else(|_| {
+                debug!("using built-in default stylesheet");
+                Self::default()
+            })
+            .ui
+            .background_color
     }
 
     pub fn load() -> Result<Self> {

--- a/crates/show/src/main.rs
+++ b/crates/show/src/main.rs
@@ -27,7 +27,7 @@ struct Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let styles = Stylesheet::load()?;
+    let background_color = Stylesheet::load_background_color();
     let mut fb = Framebuffer::new("/dev/fb0")?;
 
     let vw = fb.var_screen_info.xres_virtual as usize;
@@ -37,9 +37,9 @@ fn main() -> Result<()> {
     let mut frame = if !cli.clear {
         fb.read_frame().to_vec()
     } else {
-        let r = styles.ui.background_color.r();
-        let g = styles.ui.background_color.g();
-        let b = styles.ui.background_color.b();
+        let r = background_color.r();
+        let g = background_color.g();
+        let b = background_color.b();
 
         [b, g, r, 0xff]
             .into_iter()
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
     };
 
     if cli.darken {
-        darken(&mut frame, styles.ui.background_color, 192);
+        darken(&mut frame, background_color, 192);
     }
 
     if let Some(path) = cli.path {


### PR DESCRIPTION
I am investigating why shutting down takes some time and found that `show` only draws a splash without text. It does `Stylesheet::load()`,  so it reads three fonts but the only field it uses is `ui.background_color`.

Every theme loads NotoSansCJK.otf (17.03 MB) as a fallback. The theme's `ui_font` and `guide_font` are loaded on top of that. That's 2 * 4.72 MB on the SpruceOS theme and 2 * 131 KB on the stock one, bringing the total to 26.5 MB vs 17.3 MB.

On a Miyoo Mini Flip, that is most of show's runtime. Cold cache with SpruceOS theme (minimum of ten run and worst run in brackets):

  | Before | After
-- | -- | --
show --darken | 2.07 s (2.95 s) | 0.21 s (0.50 s)
show --clear | 1.78 s (2.96 s) | 0.07 s (0.38 s)
