### PR TITLE
perf: mmap font files instead of reading them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "log",
+ "memmap2",
  "nix 0.29.0",
  "rusqlite",
  "rusqlite_migration",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ futures = "0.3.31"
 image = { version = "0.25.10", default-features = false }
 itertools = "=0.13.0"
 lazy_static = "1.5.0"
+memmap2 = "0.9.11"
 log = "0.4.28"
 nix = "=0.29.0"
 qrcode = "0.14.1"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -28,6 +28,7 @@ futures.workspace = true
 image = { workspace = true, features = ["gif", "jpeg", "png"] }
 itertools.workspace = true
 lazy_static.workspace = true
+memmap2.workspace = true
 log = { workspace = true, features = ["release_max_level_info"] }
 nix = { workspace = true, features = ["ioctl"] }
 rusqlite = { workspace = true, features = ["bundled", "chrono"] }

--- a/crates/common/src/stylesheet.rs
+++ b/crates/common/src/stylesheet.rs
@@ -1,10 +1,13 @@
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
 use anyhow::Result;
 use itertools::Itertools;
 use log::{debug, error, warn};
+use memmap2::Mmap;
 use rusttype::Font;
 use serde::{Deserialize, Serialize};
 
@@ -72,6 +75,29 @@ impl StylesheetColor {
     }
 }
 
+/// Memory-maps a font instead of reading the whole file upfront. The CJK fallback alone is 17 MB,
+/// while mmap loads pages on demand as glyphs are rasterized.
+///
+/// Mappings are cached by path and kept alive for the lifetime of the process, since
+/// `Font<'static>` can outlive the scope where the font was loaded.
+fn map_font(path: &Path) -> Result<&'static [u8]> {
+    static MAPPED: LazyLock<Mutex<HashMap<PathBuf, &'static [u8]>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    let mut mapped = MAPPED.lock().expect("no panics under this lock");
+    if let Some(bytes) = mapped.get(path) {
+        return Ok(bytes);
+    }
+
+    let file = File::open(path)?;
+    // SAFETY: theme fonts are not written while Allium runs; a concurrent truncation would be
+    // undefined behaviour, the standard caveat for any mapped file.
+    let mmap = unsafe { Mmap::map(&file)? };
+    let bytes: &'static [u8] = &Box::leak(Box::new(mmap))[..];
+    mapped.insert(path.to_path_buf(), bytes);
+    Ok(bytes)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StylesheetFont {
     pub path: PathBuf,
@@ -96,8 +122,7 @@ impl StylesheetFont {
 
     /// Loads the font from disk if it has not already been loaded.
     pub fn load(&mut self) -> Result<()> {
-        let bytes = fs::read(&self.path)?;
-        self.font = Font::try_from_vec(bytes);
+        self.font = Font::try_from_bytes(map_font(&self.path)?);
         if self.font.is_none() {
             error!("failed to load font from {:?}", self.path);
         }


### PR DESCRIPTION
This PR together with #171 continues my investigation on what takes time on shutdown and I found that every process building a Stylesheet reads its fonts into memory up front. `StylesheetFont::load()` does an `fs::read()` followed by `Font::try_from_vec()`.

With the SpruceOS theme, that means reading 26.5 MB: twice the UI font at 4.72 MB, and NotoSansCJK.otf at 17.03 MB. Most of that is fixed, every theme loads the CJK fallback, and only ui_font and guide_font different. Mapping the fonts lets the kernel load only the pages that are actually used. A Latin UI barely uses the 17 MB CJK fallback.

On a Miyoo Mini Flip with cold cache and SpruceOS theme (minimum of ten runs, worst in brackets):

  | Before | After
-- | -- | --
say "Powering off" | 1.98 s (2.76 s) | 0.37 s (0.51 s)

The shutdown sequence (show --darken, say, and a 250 ms sleep) goes from 4.40 s to 0.93 s.

The mapping is cached by path and intentionally kept alive for the lifetime of the process. The previous code kept the font data alive until exit as anonymous memory. With mmap, the pages are file-backed and clean pages can be discarded under memory pressure and loaded again when needed.

The main trade-off is that rasterising a glyph can now cause a page fault from the SD card. I tested a 83-entry game list with a cold cache and scrolling looks smooth on the device. Navigating the rest of the interface and switching themes are unaffected too.

This also removes the same startup cost from allium-launcher, alliumd, activity-tracker, and screenshot-viewer. After this change the startup and shutdown feels a lot faster.